### PR TITLE
condence code & visuals

### DIFF
--- a/inst/pages/img-quality-control.qmd
+++ b/inst/pages/img-quality-control.qmd
@@ -4,77 +4,77 @@
 
 ### Introduction
 
-The analyses demonstrated here will use 313-plex Xenium data (10x Genomics) of a human breast cancer biopsy section [@Janesick2023] and the 1k-plex CosMX data (Nanostring) of a mouse brain sample.
+The analyses demonstrated here will use 313-plex Xenium data (10x Genomics) of a human breast cancer biopsy section [@Janesick2023] and the 1k-plex CosMx data (Nanostring) of a mouse brain sample.
 
 For the remainder of this Chapter, we will show the two examples in parallel, highlighting when needed the differences between the platforms.
 
 ### Dependencies
 
 ```{r deps, message=FALSE, warning=FALSE}
+library(osfr)
 library(dplyr)
 library(tidyr)
 library(ggplot2)
 library(patchwork)
-library(SpatialExperiment)
 library(SpaceTrooper)
+library(SpatialExperiment)
 library(SpatialExperimentIO)
-library(osfr)
 ```
 
 ## Data import
 
-`r BiocStyle::Biocpkg("SpatialExperimentIO")` provides functions to import CosMX, Xenium, and MERSCOPE datasets in Bioconductor, starting from the output provided by the three platforms.
+`r BiocStyle::Biocpkg("SpatialExperimentIO")` provides functions to import CosMx, Xenium, and MERSCOPE datasets in Bioconductor, starting from the output provided by the three platforms.
 
-### CosMX
+### CosMx
 
-First, we load the CosMX dataset:
+First, we load the CosMx dataset:
 
-```{r load-cosmx, message=FALSE, warning=FALSE}
+```{r load-cos, message=FALSE, warning=FALSE}
 # retrieve CosMx dataset from OSF repo
-osf <- osfr::osf_retrieve_node("https://osf.io/5n4q3")
-tbl <- osfr::osf_ls_files(osf, "CosMx1k_MouseBrain1")
+osf <- osf_retrieve_node("https://osf.io/5n4q3")
+tbl <- osf_ls_files(osf, "CosMx1k_MouseBrain1")
 tbl <- tbl[!grepl("tx_file", tbl$name), ] # skip molecules
 dir.create(dir <- tempfile())
-osfr::osf_download(tbl, dir, verbose=FALSE)
+osf_download(tbl, dir, verbose=FALSE)
 
 ## Load into SpatialExperiment
 ## Note that we are using SpaceTrooper's version to add metadata info (TODO: PR to SpatialExperimentIO)
-cosmx <- readCosmxSPE(dir)
+cos <- readCosmxSPE(dir)
 
 # add cell boundary polygons
 fnm <- file.path(dir, "polygons.csv.gz")
 pol <- readPolygonsCosmx(fnm)
-idx <- sprintf("f%s_c%s", cosmx$fov, cosmx$cellID)
-cosmx$polygons <- pol[match(idx, pol$cell_id), ]
+idx <- sprintf("f%s_c%s", cos$fov, cos$cellID)
+cos$polygons <- pol[match(idx, pol$cell_id), ]
 
 # add info for 'SpaceTrooper'
-metadata(cosmx)$technology <- "Nanostring_CosMx"
-cosmx$sample_id <- "CosMx"
-cosmx
+metadata(cos)$technology <- "Nanostring_CosMx"
+cos$sample_id <- "CosMx"
+cos
 ```
 ### Xenium
 
-We now read load Xenium data:
+We now load Xenium data:
 
-```{r load-xenium, message=FALSE, warning=FALSE}
+```{r load-xen, message=FALSE, warning=FALSE}
 # retrieve Xenium dataset from OSF repo
-tbl <- osfr::osf_ls_files(osf, "Xenium_HumanBreast_Janesick")
+tbl <- osf_ls_files(osf, "Xenium_HumanBreast1_Janesick")
 tbl <- tbl[!grepl("transcripts", tbl$name), ] # skip molecules
 dir.create(dir <- tempfile())
-osfr::osf_download(tbl, dir, verbose=FALSE)
+osf_download(tbl, dir, verbose=FALSE)
 
 # read into 'SpatialExperiment'
-xenium <- SpatialExperimentIO::readXeniumSXE(dir)
+xen <- readXeniumSXE(dir)
 
 # add cell boundary polygons
 fnm <- file.path(dir, "cell_boundaries.parquet")
 pol <- readPolygonsXenium(fnm)
-xenium <- addPolygonsToSPE(xenium, pol)
+xen <- addPolygonsToSPE(xen, pol)
 
 # add info for 'SpaceTrooper'
-metadata(xenium)$technology <- "10x_Xenium"
-xenium$sample_id <- "Xenium"
-xenium
+metadata(xen)$technology <- "10x_Xenium"
+xen$sample_id <- "Xenium"
+xen
 ```
 
 ## Visualization
@@ -83,62 +83,55 @@ Imaging-based ST data relies on imaging a 2D tissue section. Hence, an advantage
 
 The easiest way to visualize the data is by representing the cells by its centroid. This is useful to have a global bird's-eye-view of the tissue.
 
-Here, we visualize the CosMX data.
-
-```{r plot-cosmx-xy, out.width="66%", fig.align="center"}
-plotCentroids(cosmx)
+```{r plot-xy}
+plotCentroids(cos) +
+plotCentroids(xen)
 ```
 
-A similar plot can be obtained for the Xenium data.
+It may be useful to visualize the centroids color-coded by cell features: for instance the CosMx output includes the fluorescence intensities of a set of antibodies that mark the nuclei and cell surfaces.
 
-```{r plot-xenium-xy, out.width="66%", fig.align="center"}
-plotCentroids(xenium)
+Here, we show the distribution of DAPI across the CosMx sample.
+
+```{r plot-cos-xy-dapi,out.width="66%", fig.align="center"}
+plotCentroids(cos, colour_by="Mean.DAPI")
 ```
 
-It may be useful to visualize the centroids color-coded by cell features: for instance the CosMX output includes the fluorescence intensities of a set of antibodies that mark the nuclei and cell surfaces.
+While plotting centroids is good for a overview of the macro tissue structure, when zooming into a specific area, the centroids do not provide the full information. For instance, looking at one FOV of the CosMx data it is hard to distinguish between areas with low cell densities and areas with large cells.
 
-Here, we show the distribution of DAPI across the CosMX sample.
-
-```{r plot-cosmx-xy-dapi,out.width="66%", fig.align="center"}
-plotCentroids(cosmx, colour_by = "Mean.DAPI")
-```
-
-While plotting centroids is good for a overview of the macro tissue structure, when zooming into a specific area, the centroids do not provide the full information. For instance, looking at one FOV of the CosMX data it is hard to distinguish between areas with low cell densities and areas with large cells.
-
-```{r plot-cosmx-xy-fov1, out.width="66%", fig.align="center"}
-plotCentroids(cosmx[,cosmx$fov == 99], size = 1, colour_by = "Mean.DAPI")
+```{r plot-cos-xy-fov1, out.width="66%", fig.align="center"}
+plotCentroids(cos[,cos$fov == 99], size=1, colour_by="Mean.DAPI")
 ```
 
 We can improve the visualization by leveraging the polygons stored in the object from the cell segmentation step.
 
-```{r plot-cosmx-polu-fov1, out.width="66%", fig.align="center"}
-plotPolygons(cosmx[,cosmx$fov == 99], colour_by = "Mean.DAPI")
+```{r plot-cos-polu-fov1, out.width="66%", fig.align="center"}
+plotPolygons(cos[,cos$fov == 99], colour_by="Mean.DAPI")
 ```
 
 The same function can be applied to Xenium data, but here we do not have independent FOVs. Hence, we define a zoom area based on the slide's global coordinates.
 
-```{r plot-xenium-poly, out.width="66%", fig.align="center"}
-box <- (spatialCoords(xenium)[,1] >= 4000 & spatialCoords(xenium)[,1] <= 6000) &
-  (spatialCoords(xenium)[,2] >= 0 & spatialCoords(xenium)[,2] <= 2000)
-plotPolygons(xenium[,box], colour_by = "transcript_counts")
+```{r plot-xen-poly, out.width="66%", fig.align="center"}
+box <- (spatialCoords(xen)[,1] >= 4000 & spatialCoords(xen)[,1] <= 6000) &
+  (spatialCoords(xen)[,2] >= 0 & spatialCoords(xen)[,2] <= 2000)
+plotPolygons(xen[,box], colour_by="transcript_counts")
 ```
 
 Note that while it is possible to use `plotPolygonsSPE` on the entire slide, this may be slow and require large amounts of RAM. Since the polygons at that zoom level will be very small and practically indistinguishable to points, we advise against generating a whole-slide polygons plot.
 
-### CosMX-specific visualizations
+### CosMx-specific visualizations
 
-Unlike, Xenium and MERSCOPE, CosMX does not stitch fields of view (FOVs) in a single image, but rather treats each FOV independently. The `colData` of the `SpatialExperiment` object resulting from a CosMX import will include the FOV of each cell, but it is sometimes tricky to understand (or remember) the relative position of each FOV within the slide.
+Unlike, Xenium and MERSCOPE, CosMx does not stitch fields of view (FOVs) in a single image, but rather treats each FOV independently. The `colData` of the `SpatialExperiment` object resulting from a CosMx import will include the FOV of each cell, but it is sometimes tricky to understand (or remember) the relative position of each FOV within the slide.
 
 The `plotCellsFovs` function provides an easy way to map the FOV within the slide.
 
 ```{r plot-fov-map, out.width="66%", fig.align="center"}
-plotCellsFovs(cosmx)
+plotCellsFovs(cos)
 ```
 
 In addition, the `plotZoomFovsMap` provides a way to zoom on a subset of FOVs, while also visualizing the global structure of the tissue.
 
 ```{r plot-fov-zoom, out.width="100%", fig.align="center"}
-plotZoomFovsMap(cosmx, fovs=99, colour_by = "Mean.DAPI")
+plotZoomFovsMap(cos, fovs=99, colour_by="Mean.DAPI")
 ```
 
 ## Simple QC Metrics
@@ -147,7 +140,7 @@ Similarly to single-cell RNA-seq, quality control (QC) is an important step to r
 
 Unlike single-cell RNA-seq and sequencing-based ST, most imaging-based ST platforms do not measure the whole transcriptome, nor an "unbiased" sample of it, but rely on the design of gene panels. 
 
-Depending on the platform and the application, such gene panels may be pan-tissue or targeting specific tissues or cell types. Moreover, they vary from a few hundreds (e.g., 313 in the first Xenium panel) to several thousands (e.g., the 5k Xenium panel or the 6k and 18k CosMX panel). Hence, unlike in sequencing-based platforms, we may not have enough ribosomal or mitochondrial transcripts to use for computing QC metrics. However, imaging-based platforms provide a set of negative probes that can be used to check for aspecific RNA captures.
+Depending on the platform and the application, such gene panels may be pan-tissue or targeting specific tissues or cell types. Moreover, they vary from a few hundreds (e.g., 313 in the first Xenium panel) to several thousands (e.g., the 5k Xenium panel or the 6k and 18k CosMx panel). Hence, unlike in sequencing-based platforms, we may not have enough ribosomal or mitochondrial transcripts to use for computing QC metrics. However, imaging-based platforms provide a set of negative probes that can be used to check for aspecific RNA captures.
 
 Finally, imaging-based platforms include, in addition to transcripts data, morphology information (such as the area and eccentricity of the segmented cells) and intensity information from antibody stains (such as those targeting the nuclei or the cell membrane).
 
@@ -159,31 +152,31 @@ Finally, imaging-based platforms include, in addition to transcripts data, morph
 - `log2CountArea`: the log2 of the count density, i.e., the number of transcripts divided by the cell area.
 
 
-```{r qc-metrics-xenium}
+```{r qc-metrics-xen}
 ## These lines are needed temporarily because we are working with a STexampleData object
 ## rather than one imported from the 10X Genomics output
-xenium$AspectRatio <- computeAspectRatioFromPolygons(xenium$polygons)
-xenium$Area_um <- xenium$cell_area
+xen$AspectRatio <- computeAspectRatioFromPolygons(xen$polygons)
+xen$Area_um <- xen$cell_area
 
-xenium <- spatialPerCellQC(xenium)
-colData(xenium)[,c("Area_um", "log2AspectRatio", "log2CountArea")]
+xen <- spatialPerCellQC(xen)
+colData(xen)[,c("Area_um", "log2AspectRatio", "log2CountArea")]
 ```
 
-In addition, for CosMX data, it is important to calculate the disance from the  horizontal, vertical, and closest FOV border: `dist_border_x`, `dist_border_y` , `dist_border`, respectively.
+In addition, for CosMx data, it is important to calculate the distance from the horizontal, vertical, and closest FOV border: `dist_border_x`, `dist_border_y` , `dist_border`, respectively.
 
-```{r qc-metrics-cosmx}
-cosmx <- spatialPerCellQC(cosmx)
-colData(cosmx)[,c("dist_border_x", "dist_border_y", "dist_border")]
+```{r qc-metrics-cos}
+cos <- spatialPerCellQC(cos)
+colData(cos)[, grep("^dist", names(colData(cos)))]
 ```
 
 Imaging-based ST data relies on imaging a 2D tissue section.
 Cells thus represent a slice through a 3D system, and we expect a tight relationship between a cell's counts and its area.
-When we inspect total counts and cell areas as separate (univariate) distributions, both appear to follow approximate log-normal distributions, both in CosmX:
+When we inspect total counts and cell areas as separate (univariate) distributions, both appear to follow approximate log-normal distributions, both in CosMx:
 
-```{r plot-qc-1d-cosmx, fig.width=6, fig.height=2}
+```{r plot-qc-1d-cos, warning=FALSE, fig.width=6, fig.height=2}
 #| code-fold: true
 
-df <- data.frame(colData(cosmx))
+df <- data.frame(colData(cos))
 
 fd <- pivot_longer(df, c("Area_um", "total"))
 mu <- summarise_at(group_by(fd, name), "value", median)
@@ -199,10 +192,10 @@ ggplot(fd, aes(value)) + facet_grid(~name) +
 
 And in Xenium:
 
-```{r plot-qc-1d-xenium, fig.width=6, fig.height=2}
+```{r plot-qc-1d-xen, warning=FALSE, fig.width=6, fig.height=2}
 #| code-fold: true
 
-dfx <- data.frame(colData(xenium))
+dfx <- data.frame(colData(xen))
 
 fd <- pivot_longer(dfx, c("cell_area", "total_counts"))
 mu <- summarise_at(group_by(fd, name), "value", median)
@@ -216,45 +209,35 @@ ggplot(fd, aes(value)) + facet_grid(~name) +
     theme_minimal() + theme(panel.grid.minor=element_blank())
 ```
 
-Note that the cell area is much bigger in Xenium, mostly because of the different cell segmentation algorithm used.
+Note that the cell area is much bigger in Xenium, mostly because of the different cell segmentation algorithms used.
 
 We can also view the distribution of these metrics across the tissue slide by plotting cell centroids colored by total counts and cell area, respectively:
 
-```{r plot-qc-xy-cosmx}
+```{r plot-qc-xy, fig.width=9, fig.height=6}
 #| code-fold: true
-plotCentroids(cosmx, colour_by = "total")
-plotCentroids(cosmx, colour_by = "Area_um")
+p1 <- plotCentroids(cos, colour_by="total")
+p2 <- plotCentroids(cos, colour_by="Area_um")
+p3 <- plotCentroids(xen, colour_by="total_counts")
+p4 <- plotCentroids(xen, colour_by="cell_area") 
+(p1/p2 | p3/p4) & coord_equal()
 ```
 
-```{r plot-qc-xy-xenium}
+In a bivariate setting, we observe a positive relationship between counts and area (as expected). 
+However, this dependency is not always linear and may exhibit a bimodal distribution.
+
+```{r plot-qc-2d-one, message=FALSE, warning=FALSE, fig.width=6, fig.height=3}
 #| code-fold: true
-plotCentroids(xenium, colour_by = "total_counts")
-plotCentroids(xenium, colour_by = "cell_area")
-```
-
-In a bivariate setting, however, we observe, as expected, a positive relationship between counts and area. However such dependencies is not always linear and may exhibit a bimodal distribution.
-
-```{r plot-qc-2d-one, fig.width=3, fig.height=3}
-#| code-fold: true
-ggplot(df, aes(Area_um, total)) + 
-    geom_point(shape=16, size=0.1, alpha=0.1) +
-    geom_smooth(method="lm", color = "blue") +
-    scale_x_continuous(trans="log10") +
-    scale_y_continuous(trans="log10") +
-    theme_minimal() + theme(
-        aspect.ratio=1,
-        panel.grid.minor=element_blank()) +
-  ggtitle("CosMX")
-
-ggplot(dfx, aes(cell_area, total_counts)) + 
-    geom_point(shape=16, size=0.1, alpha=0.1) +
-    geom_smooth(method="lm", color = "blue") +
-    scale_x_continuous(trans="log10") +
-    scale_y_continuous(trans="log10") +
-    theme_minimal() + theme(
-        aspect.ratio=1,
-        panel.grid.minor=element_blank()) +
-  ggtitle("Xenium")
+.p <- \(df, x) {
+    ggplot(df, aes(.data[[x]], total)) + 
+        geom_point(shape=16, size=0.1, alpha=0.1) + 
+        geom_smooth(method="lm", color="blue") +
+        scale_x_log10() + scale_y_log10() +
+        theme_minimal() + theme(
+            aspect.ratio=1, 
+            panel.grid.minor=element_blank())
+}
+.p(df, "Area_um") + ggtitle("CosMx") +
+.p(dfx, "cell_area") + ggtitle("Xenium")
 ```
 
 In some cases, a peculiar count-area distribution might be indicative of cell segmentation issues. 
@@ -262,28 +245,28 @@ When groups of cells are merged together, for example, we might observe fewer co
 
 An useful metric to explore this issue is the `log2CountArea`, which estimates the transcript density for each cell.
 
-```{r tx-density}
+```{r tx-density, fig.width=12, fig.height=4.5}
 #| code-fold: true
-
-plotCentroids(cosmx, colour_by = "log2CountArea")
-plotCentroids(xenium, colour_by = "log2CountArea")
+plotCentroids(cos, colour_by="log2CountArea") +
+plotCentroids(xen, colour_by="log2CountArea") +
+    plot_layout() & coord_equal()
 ```
 
 Considering the spatial distribution of the transcript density, it is reasonable to assume that they represent distinct transcriptional states (not technical artefacts), with the exception of a small area at the bottom-center of the Xenium slide.
 
-### CosMX-specific considerations
+### CosMx-specific considerations
 
-Recall that the CosMX platform allows the user to place independent FOV across the tissue slide and does not stitch together adjacent FOVs.
+Recall that the CosMx platform allows the user to place independent FOV across the tissue slide and does not stitch together adjacent FOVs.
 
 Assuming FOV placement was done with the aim of capturing biologically interesting regions of the tissue, we would expect every FOV to capture a decent number of cells.
 Issues in image registration or IF staining, however, may affect spot calling and cell segmentation, and can yield FOVs with virtually no cells.
 We thus advice inspecting the number of cells across FOVs:
 
-```{r cosmx-plot-ns, fig.width=4, fig.height=2}
+```{r cos-plot-ns, fig.height=2, out.width="100%"}
 #| code-fold: true
-ns <- as.data.frame(table(fov=cosmx$fov), responseName="n_cells")
-ggplot(ns, aes(fov, n_cells)) + geom_col() +
-    scale_x_discrete(breaks=c(1, seq(5, max(cosmx$fov), 5))) +
+ns <- as.data.frame(table(fov=cos$fov), responseName="n_cells")
+ggplot(ns, aes(fov, n_cells)) + geom_col(fill="royalblue") +
+    scale_x_discrete(breaks=c(1, seq(5, max(cos$fov), 5))) +
     scale_y_continuous(limits=c(0, 1e3), n.breaks=4) +
     labs(x="field of view (FOV)", y="# cells") +
     coord_cartesian(expand=FALSE) + theme_minimal()
@@ -294,9 +277,9 @@ Of course, such effects will also be driven by differences in subpopulation comp
 However, gross differences in detection efficacy, IF staining, spot calling, segmentation etc. often still manifest in FOV-level shifts in IF stains and/or RNA target, negative probe, system control counts.
 A simple spot-check is the following type of visualization, but more thorough investigation is advisable 'in the wild', especially so in challenging types of tissue:
 
-```{r cosmx-plot-qc, warning=FALSE, fig.width=12, fig.height=4}
+```{r cos-plot-qc, warning=FALSE, fig.width=12, fig.height=4}
 #| code-fold: true
-df <- data.frame(colData(cosmx))
+df <- data.frame(colData(cos))
 vs <- "Mean"
 vs <- grep(vs, names(df), value=TRUE)
 vs <- c(vs, "Area_um", "log2CountArea", "detected", "total", "ctrl_total_ratio")
@@ -309,7 +292,7 @@ fd <- pivot_longer(df, vs) |>
 ggplot(fd, aes(factor(fov), value)) + 
     facet_wrap(~name, nrow=2, scales="free_y") +
     geom_boxplot(linewidth=0.2, outlier.size=0.2) +
-    scale_x_discrete(breaks=c(1, seq(5, max(cosmx$fov), 5))) +
+    scale_x_discrete(breaks=c(1, seq(5, max(cos$fov), 5))) +
     labs(x="field of view (FOV)", y=NULL) + theme_minimal()
 ```
 
@@ -324,79 +307,27 @@ To investigate potential artefacts related to this, we can use the distance to F
 We can *roughly* estimate cell radii as $A=\pi r^2$ $\leftrightarrow r=\sqrt{A/\pi}$, and use this as a threshold on FOV border distances.
 In other words, we flag a cell when its centroid is closer to any FOV border than the radius of an average circular cell:
 
-```{r cosmx-est-r}
-(r <- sqrt(mean(cosmx$Area)/pi))
+```{r cos-est-r}
+(r <- sqrt(mean(cos$Area)/pi))
 ```
 
 Next, let us visualize total RNA counts against distance to FOV borders, setting the above threshold on the latter; we also include rolling means to better highlight global trends:
 
-```{r comsmx-plot-ds, warning=FALSE}
+```{r cos-plot-ds, message=FALSE, warning=FALSE, fig.width=9, fig.height=4}
 #| code-fold: true
-df <- data.frame(colData(cosmx))
-
-p1 <- df |>
-  ggplot(aes(dist_border, detected)) +
-  geom_point(color="grey", size=0.1) +
-  geom_smooth() +
-  xlab("Minimum distance to border (pixel)") +
-  ylab("Number of detected genes") +
-  xlim(0, 300) +
-  ylim(0, 400) +
-  geom_vline(xintercept = r, linetype = "longdash") +
-  geom_vline(xintercept = 50, linetype = "dashed") +
-  ggtitle("Detected genes")  + theme_minimal()
-
-p2 <- df |>
-  ggplot(aes(dist_border, total)) +
-  geom_point(color="grey", size=0.1) +
-  geom_smooth() +
-  xlab("Minimum distance to border (pixel)") +
-  ylab("Total count") +
-  xlim(0, 500) +
-  ylim(0, 2000) +
-  geom_vline(xintercept = r, linetype = "longdash") + 
-  geom_vline(xintercept = 50, linetype = "dashed") +
-  theme_minimal() +
-  ggtitle("Total count")
-
-p3 <- df |>
-  ggplot(aes(dist_border, Area_um)) +
-  geom_point(color="grey", size=0.1) +
-  geom_smooth() +
-  xlab("Minimum distance to border (pixel)") +
-  ylab("Cell Area (um)") +
-  xlim(0, 500) +
-  ylim(0, 200) +
-  geom_vline(xintercept = r, linetype = "longdash") + 
-  geom_vline(xintercept = 50, linetype = "dashed") +
-  theme_minimal() +
-  ggtitle("Cell Area")
-
-p4 <- df |>
-  ggplot(aes(dist_border_x, log2AspectRatio)) +
-  geom_point(color="grey", size=0.1) +
-  geom_smooth() +
-  xlab("Minimum distance to x border (pixel)") +
-  ylab("log2 Aspect Ratio") +
-  xlim(0, 500) +
-  geom_vline(xintercept = r, linetype = "longdash") + 
-  geom_vline(xintercept = 50, linetype = "dashed") +
-  theme_minimal() +
-  ggtitle("Aspect Ratio")
-
-p5 <- df |>
-  ggplot(aes(dist_border_y, log2AspectRatio)) +
-  geom_point(color="grey", size=0.1) +
-  geom_smooth() +
-  xlab("Minimum distance to y border (pixel)") +
-  ylab("log2 Aspect Ratio") +
-  xlim(0, 500) +
-  geom_vline(xintercept = r, linetype = "longdash") + 
-  geom_vline(xintercept = 50, linetype = "dashed") +
-  theme_minimal() +
-  ggtitle("Aspect Ratio")
-
-(p2 + p3) / (p4 + p5)
+df <- data.frame(colData(cos))
+.p <- \(df, x, y) {
+    ggplot(df, aes(.data[[x]], .data[[y]])) +
+        geom_point(color="grey", size=0.1) +
+        geom_smooth() + theme_minimal() +
+        geom_vline(xintercept=r, linetype="longdash") +
+        geom_vline(xintercept=50, linetype="dashed")
+}
+p1 <- .p(df, "dist_border", "total") + xlim(0, 500) + ylim(0, 2000)
+p2 <- .p(df, "dist_border", "Area_um") + xlim(0, 500) + ylim(0, 200)
+p3 <- .p(df, "dist_border_x", "log2AspectRatio") + xlim(0, 500)
+p4 <- .p(df, "dist_border_y", "log2AspectRatio") + xlim(0, 500)
+(p1 + p2) / (p3 + p4) 
 ```
 
 We observe about `r round(100*mean(df$dist_border < r), 1)`% of cells falling below $r$ (long dashed line) and `r round(100*mean(df$dist_border < 50), 1)`% of cells falling below 50 pixels (short dashed line).
@@ -406,73 +337,80 @@ These cells exhibit lower total counts and smaller segmented areas, as well as a
 To mitigate potential artefacts in downstream analyses, we may choose to filter out these cells, or otherwise flag them as potentially problematic events to be kept a cautionary eye on. In addition, `r BiocStyle::Biocpkg("SpaceTrooper")` uses the distance to border combined with the aspect ratio in its combined quality score calculations (see below).
 
 
-```{r cosmx-plot-ex}
+```{r cos-plot-ex}
 #| code-fold: true
-cosmx$ex <- df$dist_border < 50
-plotCentroids(cosmx, colour_by = "ex") +
-  scale_color_manual(values = c("grey", "blue"))
+cos$ex <- df$dist_border < 50
+plotCentroids(cos, colour_by="ex") +
+  scale_color_manual(values=c("grey", "blue"))
 
-## plotPolygons(cosmx[,cosmx$fov %in% c(7, 8, 11, 12)], colour_by = "ex")
+## plotPolygons(cos[,cos$fov %in% c(7, 8, 11, 12)], colour_by="ex")
 ```
 
-## Identification of low-quality cells
+## Identifying low-quality cells
 
 We can now use the QC metrics calculated above to flag low-quality cells. 
 
-First, we can inspect individual metrics looking for outliers in their distribution. Depending on the metric, we are interested in low-end or high-end outliers (or both). For instance, we may want to exclude too small or too large cells as potential artifacts.
+First, we can inspect individual metrics looking for outliers in their distribution.
+Depending on the metric, we are interested in low-end or high-end outliers (or both). 
+For instance, we may want to exclude too small/large cells as potential artifacts.
 
-`r BiocStyle::Biocpkg("SpaceTrooper")` provides a function to compute outliers of the distribution of any QC metric present in the colData of the object. We can then visualize the distribution and the outlier threshold with a histogram.
+`r BiocStyle::Biocpkg("SpaceTrooper")` provides a function to compute outliers 
+of the distribution of any QC metric present in the `colData` of the object. 
+We can then visualize the distribution and outlier threshold with a histogram.
 
-```{r outlier-cosmx-area}
-cosmx <- computeSpatialOutlier(cosmx, compute_by="Area_um", method="mc")
-plotMetricHist(cosmx, metric="Area_um", use_fences="Area_um_outlier_mc")
+```{r outlier-cos, fig.height=4, out.width="66%"}
+cos <- computeSpatialOutlier(cos, compute_by="Area_um", method="mc")
+cos <- computeSpatialOutlier(cos, compute_by="total", method="mc")
+plotMetricHist(cos, metric="Area_um", use_fences="Area_um_outlier_mc") /
+plotMetricHist(cos, metric="total", use_fences="total_outlier_mc")
 ```
 
-```{r outlier-cosmx-tot}
-cosmx <- computeSpatialOutlier(cosmx, compute_by="total", method="mc")
-plotMetricHist(cosmx, metric="total", use_fences="total_outlier_mc")
+For instance, in the CosMx data, we identify `r sum(cos$Area_um_outlier_mc)` outliers for cell area and `r sum(cos$total_outlier_mc)` outliers for total counts. 
+
+```{r outlier-xen, fig.height=4, out.width="66%"}
+xen <- computeSpatialOutlier(xen, compute_by="cell_area", method="mc")
+xen <- computeSpatialOutlier(xen, compute_by="total_counts", method="mc")
+plotMetricHist(xen, metric="cell_area", use_fences="cell_area_outlier_mc") /
+plotMetricHist(xen, metric="total_counts", use_fences="total_counts_outlier_mc")
 ```
 
-For instance, in the CosMX data, we identify `r sum(cosmx$Area_um_outlier_mc)` outliers for cell area and `r sum(cosmx$total_outlier_mc)` outliers for total counts. 
-
-```{r outlier-xenium-area}
-xenium <- computeSpatialOutlier(xenium, compute_by="cell_area", method="mc")
-plotMetricHist(xenium, metric="cell_area", use_fences="cell_area_outlier_mc")
-```
-
-```{r outlier-xenium-tot}
-xenium <- computeSpatialOutlier(xenium, compute_by="total_counts", method="mc")
-plotMetricHist(xenium, metric="total_counts", use_fences="total_counts_outlier_mc")
-```
-
-In the Xenium data, we identify `r sum(xenium$cell_area_outlier_mc)` outliers for cell area and `r sum(xenium$total_counts_outlier_mc)` outliers for total counts. However, note that the because of the naive cell segmentation algorithm of Xenium v1, we expect some abnormally large cells in low-cell-density areas, which do not necessarily correspond to low-quality cells.
+In the Xenium data, we identify `r sum(xen$cell_area_outlier_mc)` outliers for cell area and `r sum(xen$total_counts_outlier_mc)` outliers for total counts. 
+However, note that the because of the naive cell segmentation algorithm of Xenium v1, we expect some abnormally large cells in low-cell-density areas, which do not necessarily correspond to low-quality cells.
 
 Finally, we can compute an aggregated quality score, which combines a cell's transcript density, its aspect ratio and its distance from the FoV border (only for CosMx).
 
-```{r score-cosmx}
-cosmx <- computeQCScore(cosmx)
-cosmx <- computeFilterFlags(cosmx, fs_threshold=0.75)
+```{r score-cos, fig.width=10, fig.height=5}
+cos <- computeQCScore(cos)
+cos <- computeFilterFlags(cos, fs_threshold=0.75)
 
-plotCentroids(cosmx, colour_by = "flag_score")
-plotCentroids(cosmx, colour_by = "is_fscore_outlier")
+plotCentroids(cos, colour_by="flag_score") +
+plotCentroids(cos, colour_by="is_fscore_outlier") +
+    plot_layout() & coord_equal()
 ```
 
-```{r score-xenium}
-xenium <- computeQCScore(xenium)
-xenium <- computeFilterFlags(xenium, fs_threshold=0.1)
+```{r score-xen, fig.width=12, fig.height=4}
+xen <- computeQCScore(xen)
+xen <- computeFilterFlags(xen, fs_threshold=0.1)
 
-plotCentroids(xenium, colour_by = "flag_score")
-plotCentroids(xenium, colour_by = "is_fscore_outlier")
+plotCentroids(xen, colour_by="flag_score") +
+plotCentroids(xen, colour_by="is_fscore_outlier") +
+    plot_layout() & coord_equal()
 ```
 
-We can see how the quality score flags several cells close to the tissue borders in the CosMX data and cells in the bottom-center damaged area in the Xenium data.
+We can see how the quality score flags several cells close to the tissue borders 
+in the CosMx data and cells in the bottom-center damaged area in the Xenium data.
 
 In a stringent analysis we may want to remove low-quality cells, but this has to be done with caution: before finalizing to exclude any cells, it is recommendable to inspect where these fall in the tissue.
 We would expect low-quality cells to be distributed randomly, and otherwise to accumulate at the tissue borders or in regions were tissue was, for example, smudged, detached, necrotic etc.
 In general, **spatially organized clusters of excluded cells might indicate a bias towards exclude specific types of cells** (e.g., some immune cells tend to be smaller or might otherwise contain fewer contains due to the panel design).
 Whenever possible, we advice readers to cross-check visualizations like the following with a corresponding H&E stain of the tissue, considering possible experimental faults as well as their prior knowledge on tissue pathology.
 
-
 ## Appendix
+
+### Saving
+
+```{r save-data}
+saveRDS(xen, "img-spe_qc.rds")
+```
 
 ### References {.unnumbered}


### PR DESCRIPTION
- for now, use `patchwork` to condense visual outputs
- if we prefer, we can make use of Quarto's `#| layout-ncol`  
to display plots with separate captions
- `{.panel-tabset}` would be an alternative if we want to  
keep the workflow to Xenium/CosMx-only, and hide the other