### PR TITLE
Update DESpace function

### DIFF
--- a/inst/pages/crs-spatially-variable.qmd
+++ b/inst/pages/crs-spatially-variable.qmd
@@ -139,7 +139,7 @@ plotSpots(spe,
 
 ```{r svg-DESpace, message=FALSE}
 # run DESpace
-res <- DESpace_test(spe, spatial_cluster="BayesSpace")
+res <- svg_test(spe, cluster_col="BayesSpace")
 head(res_DESpace <- res$gene_results)
 # count significant SVGs (at 5% FDR significance level)
 table(res_DESpace$FDR <= 0.05)


### PR DESCRIPTION
`DESpace_test()` function has been deprecated in the current devel version and replaced with `svg_test`.