### PR TITLE
`seq-proprocessing` restructuring; rename chapter on "feature selection & testing"

### DIFF
--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -6,7 +6,7 @@ book:
       chapters:
         - pages/bkg-introduction.qmd
         - pages/bkg-spatial-omics.qmd
-        - pages/bkg-interoperability.qmd
+        #- pages/bkg-interoperability.qmd
         - pages/bkg-infrastructure.qmd
         - pages/bkg-importing.qmd
         - pages/bkg-datasets.qmd
@@ -17,35 +17,35 @@ book:
         - pages/seq-quality-control.qmd
         - pages/seq-processing.qmd
         - pages/seq-deconvolution.qmd
-        - pages/seq-workflow-dlpfc-spatiallibd.qmd
-        - pages/seq-workflow-visium-crc.qmd
-        - pages/seq-workflow-visium-hd.qmd
-    - part: "Imaging-based platforms"
-      chapters:
-        - pages/img-introduction.qmd
-        - pages/img-segmentation.qmd
-        - pages/img-quality-control.qmd
-        - pages/img-processing.qmd
-        - pages/img-neighbors.qmd
-        - pages/img-cell-comm.qmd
-        - pages/img-workflow-xenium.qmd
+    #     - pages/seq-workflow-dlpfc-spatiallibd.qmd
+    #     - pages/seq-workflow-visium-crc.qmd
+    #     - pages/seq-workflow-visium-hd.qmd
+    # - part: "Imaging-based platforms"
+    #   chapters:
+    #     - pages/img-introduction.qmd
+    #     - pages/img-segmentation.qmd
+    #     - pages/img-quality-control.qmd
+    #     - pages/img-processing.qmd
+    #     - pages/img-neighbors.qmd
+    #     - pages/img-cell-comm.qmd
+    #     - pages/img-workflow-xenium.qmd
     - part: "Platform-independent analyses"
       chapters:
         - pages/crs-dimension-reduction.qmd
         - pages/crs-clustering.qmd
         - pages/crs-features.qmd
         - pages/crs-signatures.qmd
-        - pages/crs-spat-stat.qmd
-    - part: "Cross-platform analyses"
-      chapters:
-        - pages/crs-registration.qmd
-        - pages/crs-imputation.qmd
-        - pages/crs-workflow-xenvis.qmd
-    - part: "Multiple-sample analyses"
-      chapters:
-        - pages/mult-diff-spatial.qmd
-        - pages/mult-diff-colocalization.qmd
-        - pages/mult-structure-based.qmd
+    #     - pages/crs-spat-stat.qmd
+    # - part: "Cross-platform analyses"
+    #   chapters:
+    #     - pages/crs-registration.qmd
+    #     - pages/crs-imputation.qmd
+    #     - pages/crs-workflow-xenvis.qmd
+    # - part: "Multiple-sample analyses"
+    #   chapters:
+    #     - pages/mult-diff-spatial.qmd
+    #     - pages/mult-diff-colocalization.qmd
+    #     - pages/mult-structure-based.qmd
   appendices:
     - pages/apx-acknowledgments.qmd
     - pages/apx-related-resources.qmd

--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -6,7 +6,7 @@ book:
       chapters:
         - pages/bkg-introduction.qmd
         - pages/bkg-spatial-omics.qmd
-        #- pages/bkg-interoperability.qmd
+        - pages/bkg-interoperability.qmd
         - pages/bkg-infrastructure.qmd
         - pages/bkg-importing.qmd
         - pages/bkg-datasets.qmd
@@ -17,35 +17,35 @@ book:
         - pages/seq-quality-control.qmd
         - pages/seq-processing.qmd
         - pages/seq-deconvolution.qmd
-    #     - pages/seq-workflow-dlpfc-spatiallibd.qmd
-    #     - pages/seq-workflow-visium-crc.qmd
-    #     - pages/seq-workflow-visium-hd.qmd
+        - pages/seq-workflow-dlpfc-spatiallibd.qmd
+        - pages/seq-workflow-visium-crc.qmd
+        - pages/seq-workflow-visium-hd.qmd
     - part: "Imaging-based platforms"
       chapters:
         - pages/img-introduction.qmd
         - pages/img-segmentation.qmd
         - pages/img-quality-control.qmd
         - pages/img-processing.qmd
-    #     - pages/img-neighbors.qmd
-    #     - pages/img-cell-comm.qmd
-    #     - pages/img-workflow-xenium.qmd
+        - pages/img-neighbors.qmd
+        - pages/img-cell-comm.qmd
+        - pages/img-workflow-xenium.qmd
     - part: "Platform-independent analyses"
       chapters:
         - pages/crs-dimension-reduction.qmd
         - pages/crs-clustering.qmd
         - pages/crs-features.qmd
         - pages/crs-signatures.qmd
-    #     - pages/crs-spat-stat.qmd
-    # - part: "Cross-platform analyses"
-    #   chapters:
-    #     - pages/crs-registration.qmd
-    #     - pages/crs-imputation.qmd
-    #     - pages/crs-workflow-xenvis.qmd
-    # - part: "Multiple-sample analyses"
-    #   chapters:
-    #     - pages/mult-diff-spatial.qmd
-    #     - pages/mult-diff-colocalization.qmd
-    #     - pages/mult-structure-based.qmd
+        - pages/crs-spat-stat.qmd
+    - part: "Cross-platform analyses"
+      chapters:
+        - pages/crs-registration.qmd
+        - pages/crs-imputation.qmd
+        - pages/crs-workflow-xenvis.qmd
+    - part: "Multiple-sample analyses"
+      chapters:
+        - pages/mult-diff-spatial.qmd
+        - pages/mult-diff-colocalization.qmd
+        - pages/mult-structure-based.qmd
   appendices:
     - pages/apx-acknowledgments.qmd
     - pages/apx-related-resources.qmd

--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -25,7 +25,7 @@ book:
         - pages/img-introduction.qmd
         - pages/img-segmentation.qmd
         - pages/img-quality-control.qmd
-    #     - pages/img-processing.qmd
+        - pages/img-processing.qmd
     #     - pages/img-neighbors.qmd
     #     - pages/img-cell-comm.qmd
     #     - pages/img-workflow-xenium.qmd

--- a/inst/assets/_book.yml
+++ b/inst/assets/_book.yml
@@ -20,11 +20,11 @@ book:
     #     - pages/seq-workflow-dlpfc-spatiallibd.qmd
     #     - pages/seq-workflow-visium-crc.qmd
     #     - pages/seq-workflow-visium-hd.qmd
-    # - part: "Imaging-based platforms"
-    #   chapters:
-    #     - pages/img-introduction.qmd
-    #     - pages/img-segmentation.qmd
-    #     - pages/img-quality-control.qmd
+    - part: "Imaging-based platforms"
+      chapters:
+        - pages/img-introduction.qmd
+        - pages/img-segmentation.qmd
+        - pages/img-quality-control.qmd
     #     - pages/img-processing.qmd
     #     - pages/img-neighbors.qmd
     #     - pages/img-cell-comm.qmd

--- a/inst/pages/crs-dimension-reduction.qmd
+++ b/inst/pages/crs-dimension-reduction.qmd
@@ -79,6 +79,10 @@ reducedDimNames(spe) <- c("PCA_tx", "PCA_sp")
 
 ## Uniform manifold approximation and projection (UMAP)
 
+We can also perform non-linear dimensionality reduction using the UMAP algorithm, applied to the set of top PCs (default 50). The first two UMAP dimensions are often used for visualization purposes (although interpretation of the UMAP dimensions is difficult and can be misleading). In addition, the UMAP algorithm is stochastic, so the visual layout of the UMAP plot will change from one run to the next; setting a seed for random number generation ensures that the visualization is reproducible.
+
+Note that UMAP plots should be interpreted with caution [@Chari2023-specious]. Specifically, the UMAP algorithm can introduce misleading structure in a 2D plot, and the relative distances between points in the 2D plot are not meaningful. For this reason, we recommend using UMAP only for generating visualizations, not clustering -- any cluster labels shown on a UMAP plot should be generated using a separate clustering algorithm. Similar arguments also apply to the t-SNE algorithm, which may be used as an alternative to UMAP.
+
 The UMAP algorithm is often used for visualization purposes (although interpretation of the UMAP dimensions is difficult and can be misleading).
 
 Here, we run UMAP on both non-spatial and spatially aware PCs, retaining the first two UMAP components to be used for visualization:

--- a/inst/pages/crs-dimension-reduction.qmd
+++ b/inst/pages/crs-dimension-reduction.qmd
@@ -83,8 +83,6 @@ We can also perform non-linear dimensionality reduction using the UMAP algorithm
 
 Note that UMAP plots should be interpreted with caution [@Chari2023-specious]. Specifically, the UMAP algorithm can introduce misleading structure in a 2D plot, and the relative distances between points in the 2D plot are not meaningful. For this reason, we recommend using UMAP only for generating visualizations, not clustering -- any cluster labels shown on a UMAP plot should be generated using a separate clustering algorithm. Similar arguments also apply to the t-SNE algorithm, which may be used as an alternative to UMAP.
 
-The UMAP algorithm is often used for visualization purposes (although interpretation of the UMAP dimensions is difficult and can be misleading).
-
 Here, we run UMAP on both non-spatial and spatially aware PCs, retaining the first two UMAP components to be used for visualization:
 
 ```{r umap}

--- a/inst/pages/crs-features.qmd
+++ b/inst/pages/crs-features.qmd
@@ -49,20 +49,20 @@ In the context of single-cell and ST, differentially expressed (DE) may refer to
 Feature selection is used as a preprocessing step to identify a subset of biologically informative features (e.g. genes), in order to reduce noise (due to both technical and biological factors) and improve computational performance.
 [Note that HVGs are defined based only on molecular features (i.e. gene expression), and do not take any spatial information into account. If the spatial patterns in gene expression in a dataset mainly reflect spatial distributions of cell types (defined by gene expression), then relying on HVGs for downstream analyses may be sufficient. However, if there is further biologically meaningful spatial structure that is not captured in this way, spatially-aware methods may be needed instead.]{.aside}
 
-Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based data, or high-plex imaging based ST data; for the former, this makes the simplified assumption that spots can be treated as equivalent to cells.
+Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based ST data, or high-plex imaging based ST data; for the former, this makes the simplified assumption that spots can be treated as equivalent to cells.
 
-The set of top HVGs can then be used as the input for subsequent steps, such as dimensionality reduction and clustering. For a comprehensive discussion on HVG selection, we refer readers to [OSCA](https://bioconductor.org/books/3.19/OSCA.basic/feature-selection.html#hvg-selection).
+The set of top HVGs can then be used as the input for subsequent steps, such as dimensionality reduction and clustering. For a comprehensive discussion on HVG selection, we refer readers to [OSCA](https://bioconductor.org/books/release/OSCA.basic/feature-selection.html#hvg-selection).
 
 In this example, we use the `r BiocStyle::Biocpkg("scran")` package [@Lun2016] to identify HVGs in a two-step procedure. We first model the mean-variance relationship, which decomposes variance into a technical component (smooth fit) and biological component (deviation thereof).
-Secondly, HVGs may be selected based their rank, using a fixed number `n` or proportion `p` of genes:
-[A more stringent selection may be obtained by also adding a `FDR.threshold` on the significance of large variances *relative* to other genes.]{.aside}
+Secondly, HVGs may be selected based on their rank, using a fixed number `n` or proportion `p` of genes:
+[A more stringent selection may be obtained by also adding an `FDR.threshold` on the significance of large variances *relative* to other genes.]{.aside}
 
 ```{r hvg}
 # fit mean-variance relationship, decomposing 
 # variance into technical & biological components
 dec <- modelGeneVar(spe)
 
-# select top-2,000 ranked genes (in terms
+# select top 2,000 ranked genes (in terms
 # of their biological variance component)
 hvg <- getTopHVGs(dec, n=2e3)
 ```
@@ -80,7 +80,8 @@ curve(fit$trend(x), add = TRUE, lwd = 2, col = "tomato")
 ### Differentially expressed genes (DEGs) {#sec-crs-deg}
 
 Having clustered our spots (or cells), we can test for differentially expressed genes (DEGs) between clusters. These can be interpreted as marker genes and used to interpret clusters in terms of their function, and to help annotate them (i.e. assign biologically meaningful labels).
-For details on identifying DE genes between groups of cells from single-cell RNA-seq data, we refer readers to [OSCA](https://bioconductor.org/books/3.20/OSCA.basic/marker-detection.html). 
+
+For details on identifying DE genes between groups of cells from scRNA-seq data, we refer readers to [OSCA](https://bioconductor.org/books/release/OSCA.basic/marker-detection.html).
 
 Here, we will use pairwise t-tests and specifically test for upregulation (as opposed to downregulation), i.e. expression should be higher in the cluster for which a gene is reported to be a marker; see @sec-crs-clustering for details.
 

--- a/inst/pages/crs-features.qmd
+++ b/inst/pages/crs-features.qmd
@@ -22,6 +22,7 @@ library(ggspavis)
 library(ggrepel)
 library(nnSVG)
 library(patchwork)
+library(pheatmap)
 library(scater)
 library(scran)
 library(SpatialExperiment)
@@ -45,18 +46,43 @@ In the context of single-cell and ST, differentially expressed (DE) may refer to
 
 ### Highly variable genes (HVGs) {#sec-crs-hvg}
 
-For a comprehensive discussion on HVG selection, we refer readers to [OSCA](https://bioconductor.org/books/3.19/OSCA.basic/feature-selection.html#hvg-selection). 
-Below, we take a standard approach for selecting HVGs. For more details and examples, see @sec-seq-processing.
+Feature selection is used as a preprocessing step to identify a subset of biologically informative features (e.g. genes), in order to reduce noise (due to both technical and biological factors) and improve computational performance.
+[Note that HVGs are defined based only on molecular features (i.e. gene expression), and do not take any spatial information into account. If the spatial patterns in gene expression in a dataset mainly reflect spatial distributions of cell types (defined by gene expression), then relying on HVGs for downstream analyses may be sufficient. However, if there is further biologically meaningful spatial structure that is not captured in this way, spatially-aware methods may be needed instead.]{.aside}
+
+Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based data, or high-plex imaging based ST data; for the former, this makes the simplified assumption that spots can be treated as equivalent to cells.
+
+The set of top HVGs can then be used as the input for subsequent steps, such as dimensionality reduction and clustering. For a comprehensive discussion on HVG selection, we refer readers to [OSCA](https://bioconductor.org/books/3.19/OSCA.basic/feature-selection.html#hvg-selection).
+
+In this example, we use the `r BiocStyle::Biocpkg("scran")` package [@Lun2016] to identify HVGs in a two-step procedure. We first model the mean-variance relationship, which decomposes variance into a technical component (smooth fit) and biological component (deviation thereof).
+Secondly, HVGs may be selected based their rank, using a fixed number `n` or proportion `p` of genes:
+[A more stringent selection may be obtained by also adding a `FDR.threshold` on the significance of large variances *relative* to other genes.]{.aside}
 
 ```{r hvg}
-# fit mean-variance relationship
+# fit mean-variance relationship, decomposing 
+# variance into technical & biological components
 dec <- modelGeneVar(spe)
+
+# select top-2,000 ranked genes (in terms
+# of their biological variance component)
+hvg <- getTopHVGs(dec, n=2e3)
+```
+
+```{r plt-hvgs, fig.width=5, fig.height=4}
+#| code-fold: true
+# visualize mean-variance relationship
+par(mar = c(4, 4, 0, 0))
+fit <- metadata(dec)
+plot(fit$mean, fit$var, cex = 0.5, xlab = "mean expression", ylab = "variance")
+points(dec[hvg, "mean"], dec[hvg, "total"], cex = 0.5, col = "dodgerblue")
+curve(fit$trend(x), add = TRUE, lwd = 2, col = "tomato")
 ```
 
 ### Differentially expressed genes (DEGs) {#sec-crs-deg}
 
+Having clustered our spots (or cells), we can test for differentially expressed genes (DEGs) between clusters. These can be interpreted as marker genes and used to interpret clusters in terms of their function, and to help annotate them (i.e. assign biologically meaningful labels).
 For details on identifying DE genes between groups of cells from single-cell RNA-seq data, we refer readers to [OSCA](https://bioconductor.org/books/3.20/OSCA.basic/marker-detection.html). 
-Below, we show a potential approach, using marker detection methods on ST data, to identify DE genes between spatial clusters.
+
+Here, we will use pairwise t-tests and specifically test for upregulation (as opposed to downregulation), i.e. expression should be higher in the cluster for which a gene is reported to be a marker; see @sec-crs-clustering for details.
 
 ```{r deg, fig.width=10, fig.height=3}
 # differential gene expression analysis
@@ -64,6 +90,42 @@ mgs <- findMarkers(spe, groups=spe$BayesSpace, direction="up")
 # select for a few markers per cluster
 deg <- lapply(mgs, \(df) rownames(df)[df$Top <= 3])
 length(deg <- unique(unlist(deg)))
+```
+
+We can visualize selected marker genes as a heatmap where bins represent the average expression (here, log-transformed library size-normalized counts) of a given gene (= columns) in a given cluster (= rows).
+[To visually amplify differences, we use `scale = "column"`. This will, for every gene, subtract the mean and divide by the standard deviation across per-cluster means, bringing genes of potentially very different expression levels to a comparable scale.]{.aside}
+
+```{r plt-deg-hm, fig.width=9, fig.height=3}
+#| code-fold: true
+# compute cluster-wise averages
+pbs <- aggregateAcrossCells(spe, 
+    ids = spe$BayesSpace, subset.row = deg, 
+    use.assay.type = "logcounts", statistics = "mean")
+# use gene symbols as feature names
+mtx <- t(assay(pbs))
+colnames(mtx) <- rowData(pbs)$gene_name
+# using pheatmap package
+pheatmap(mat = mtx, scale = "column")
+```
+
+In addition, we can plot in x-y space, i.e. coloring spots by their expression of a given marker gene:
+
+```{r plt-deg-xy, fig.width=10, fig.height=6, message=FALSE}
+#| code-fold: true
+# select top-4 markers for each cluster & get gene symbols
+gs <- unique(unlist(lapply(mgs, \(df) head(rownames(df), 4))))
+gs <- rowData(spe)$gene_name[match(gs, rownames(spe))]
+# gene-wise spatial plots
+ps <- lapply(gs, \(.) {
+    plotCoords(spe, 
+        annotate = ., 
+        feature_names = "gene_name", 
+        assay_name = "logcounts") })
+# figure arrangement
+wrap_plots(ps, nrow = 4) & 
+  theme(legend.key.width = unit(0.4, "lines"), 
+        legend.key.height = unit(0.8, "lines")) & 
+  scale_color_gradientn(colors = rev(hcl.colors(9, "Rocket")))
 ```
 
 ## Spatially-aware

--- a/inst/pages/crs-features.qmd
+++ b/inst/pages/crs-features.qmd
@@ -110,10 +110,10 @@ pheatmap(mat = mtx, scale = "column")
 
 In addition, we can plot in x-y space, i.e. coloring spots by their expression of a given marker gene:
 
-```{r plt-deg-xy, fig.width=10, fig.height=6, message=FALSE}
+```{r plt-deg-xy, fig.width=10, fig.height=8, message=FALSE}
 #| code-fold: true
-# select top-4 markers for each cluster & get gene symbols
-gs <- unique(unlist(lapply(mgs, \(df) head(rownames(df), 4))))
+# select top-3 markers for each cluster & get gene symbols
+gs <- unique(unlist(lapply(mgs, \(df) head(rownames(df), 3))))
 gs <- rowData(spe)$gene_name[match(gs, rownames(spe))]
 # gene-wise spatial plots
 ps <- lapply(gs, \(.) {

--- a/inst/pages/img-quality-control.qmd
+++ b/inst/pages/img-quality-control.qmd
@@ -14,13 +14,13 @@ These datasets can be accessed through the `r BiocStyle::Biocpkg("STexampleData"
 ### Dependencies
 
 ```{r deps, message=FALSE, warning=FALSE}
-library(SpatialExperiment)
-library(STexampleData)
-library(scater)
 library(dplyr)
 library(tidyr)
+library(scater)
 library(ggplot2)
 library(patchwork)
+library(STexampleData)
+library(SpatialExperiment)
 ```
 
 

--- a/inst/pages/seq-processing.qmd
+++ b/inst/pages/seq-processing.qmd
@@ -32,16 +32,17 @@ set.seed(123)
 
 ### Load data
 
+Here, we load 10x Genomics Visium data on a postmortem human brain tissue section from the dorsolateral prefrontal cortex (DLPFC) brain region, which has undergone quality control and filtering in the preceeding @sec-seq-quality-control.
+
+<!--
 Here, we load a 10x Genomics Visium dataset that will also be used in several of the following chapters. This dataset has previously been preprocessed using tools outside R and saved in `SpatialExperiment` format, and is available for download from the `r BiocStyle::Biocpkg("STexampleData")` package.
 
 This dataset consists of one sample (Visium capture area) of postmortem human brain tissue from the dorsolateral prefrontal cortex (DLPFC) brain region, measured with the 10x Genomics Visium platform. The dataset is described in @Maynard2021.
+-->
 
 ```{r load-data, message=FALSE}
 # load data from STexampleData package
-spe <- Visium_humanDLPFC()
-
-class(spe)
-dim(spe)
+(spe <- readRDS("seq-spe_qc.rds"))
 ```
 
 
@@ -78,49 +79,28 @@ assayNames(spe)
 
 ### Highly variable genes (HVGs)
 
-Feature selection is used as a preprocessing step to identify a subset of biologically informative features (e.g. genes), in order to reduce noise (due to both technical and biological factors) and improve computational performance.
+Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based data. This makes the simplified assumption that spots can be treated as equivalent to cells.
 
-Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based ST data. As above, this makes the simplified assumption that spots can be treated as equivalent to cells.
+Here, we take a standard approach for selecting HVGs; see @sec-crs-hvg for more details. We first remove mitochondrial genes, since these tend to be very highly expressed and are not of main biological interest.
 
-The set of top HVGs can then be used as the input for subsequent steps, such as dimensionality reduction and clustering. In this example, we use the `r BiocStyle::Biocpkg("scran")` package [@Lun2016] to identify HVGs.
-
-Note that HVGs are defined based only on molecular features (i.e. gene expression), and do not take any spatial information into account. If the spatial patterns in gene expression in a dataset mainly reflect spatial distributions of cell types (defined by gene expression), then relying on HVGs for downstream analyses may be sufficient. However, if there is further biologically meaningful spatial structure that is not captured in this way, spatially-aware methods may be needed instead.
-
-To identify the set of top HVGs, we first remove mitochondrial genes, since these tend to be very highly expressed and are not of main biological interest.
-
-```{r mt}
+```{r mt, results="hold"}
 # identify mitochondrial genes
 nm <- rowData(spe)$gene_name
 mt <- grepl("^MT-", nm, ignore.case = TRUE)
 table(mt)
-
-# remove
+# remove them
 spe <- spe[!mt, ]
 ```
 
 Next, apply methods from `r BiocStyle::Biocpkg("scran")`. This gives a list of top HVGs, which can be used as the input for subsequent steps. The parameter `prop` defines the proportion of HVGs to select -- for example, `prop = 0.1` returns the top 10%. (Alternatively, argument `n` can be used to selected a fixed number of top HVGs, say 1000 or 2000.)
 
 ```{r hvgs, message=FALSE, fig.width=6, fig.height=5}
-# fit mean-variance relationship, decomposing variance into 
-# technical and biological components
+# fit mean-variance relationship
 dec <- modelGeneVar(spe)
-
 # select top HVGs
 sel <- getTopHVGs(dec, prop = 0.1)
-
 # number of HVGs selected
 length(sel)
-```
-
-```{r plt-hvgs, fig.width=5, fig.height=4}
-#| code-fold: true
-# visualize mean-variance relationship
-par(mar = c(4, 4, 0, 0))
-fit <- metadata(dec)
-plot(fit$mean, fit$var, cex = 0.5, 
-     xlab = "mean expression", ylab = "variance")
-points(dec[sel, "mean"], dec[sel, "total"], cex = 0.5, col = "dodgerblue")
-curve(fit$trend(x), add = TRUE, lwd = 2, col = "tomato")
 ```
 
 
@@ -136,17 +116,12 @@ A number of methods have been developed to identify SVGs. For more details and e
 A standard next step is to perform dimensionality reduction using principal component analysis (PCA), applied to the set of top HVGs (or SVGs). The set of top principal components (PCs) can then be used as the input for subsequent steps. Note that we have set a random seed at the start of the chapter for reproducibility. See @sec-crs-dimension-reduction for more details.
 
 ```{r pca}
-# using scater package
 spe <- runPCA(spe, subset_row = sel)
 ```
 
-In addition, we can perform nonlinear dimensionality reduction using the UMAP algorithm, applied to the set of top PCs (default 50). The top two UMAP dimensions can then be used for visualization purposes by plotting on the x and y axes. The UMAP algorithm is stochastic, so the visual layout of the UMAP plot will change from one run to the next. Setting a random seed (as above) ensures that the visualization is reproducible.
-
-Note that UMAP plots should be interpreted with caution [@Chari2023-specious]. Specifically, the UMAP algorithm can introduce misleading structure in a 2D plot, and the relative distances between points in the 2D plot are not meaningful. For this reason, we recommend using UMAP only for generating visualizations, not clustering -- any cluster labels shown on a UMAP plot should be generated using a separate clustering algorithm. Similar arguments also apply to the t-SNE algorithm, which may be used as an alternative to UMAP.
+In addition, we can perform nonlinear dimensionality reduction using the UMAP algorithm, applied to the set of top PCs (default 50). The first two UMAP dimensions can then be used for visualization purposes by plotting them on the x and y axes.
 
 ```{r umap, eval=FALSE}
-# using scater package
-# not run
 spe <- runUMAP(spe, dimred = "PCA")
 ```
 
@@ -186,7 +161,7 @@ table(spe$BayesSpace, spe$ground_truth, useNA = "ifany")
 
 Inspecting the spatial distribution of the top PCs, we can observe that the main driver of expression variability is the distinction between white matter (WM) and non-WM cortical layers.
 
-```{r plot-xy-pcs, collapse=TRUE, fig.width=8, fig.height=3}
+```{r plot-xy-pcs, collapse=TRUE, fig.width=8, fig.height=2.5}
 #| code-fold: true
 pcs <- reducedDim(spe, "PCA")
 pcs <- pcs[, seq_len(4)]
@@ -194,25 +169,22 @@ lapply(colnames(pcs), \(.) {
     spe[[.]] <- pcs[, .]
     plotCoords(spe, annotate = .)
 }) |> 
-    wrap_plots(nrow = 1) & 
+    wrap_plots(nrow = 1) & coord_equal() & 
     geom_point(shape = 16, stroke = 0, size = 0.2) & 
-    scale_color_gradientn(colors = pals::jet()) & 
-    coord_equal() & 
-    theme_void() & 
-    theme(legend.position = "bottom", 
-          plot.title = element_text(hjust = 0.5), 
-          legend.key.width = unit(0.8, "lines"), 
-          legend.key.height = unit(0.4, "lines"))
+    scale_color_gradientn(colors = pals::jet(), n.breaks = 3) & 
+    theme_void() & theme(
+        plot.title = element_text(hjust = 0.5), 
+        legend.key.width = unit(0.2, "lines"), 
+        legend.key.height = unit(0.8, "lines"))
 ```
 
 
 ## Differential expression
 
-Having clustered our spots to identify spatial domains, we can test for genes that are differentially expressed (DE) between spatial domains, which can be interpreted as marker genes for the spatial domains.
+Having clustered our spots to identify spatial domains, we can test for genes that are differentially expressed (DE) between spatial domains, which can be interpreted as marker genes for the spatial domains; see also @sec-crs-deg.
 
 Here, we will use pairwise t-tests and specifically test for upregulation (as opposed to downregulation), i.e. expression should be higher in the cluster for which a gene is reported to be a marker. See @sec-crs-clustering for additional details.
-
-Alternatively, we could also test for spatially variable genes (SVGs) within domains to identify genes with spatial expression patterns that vary independently of the spatial arrangement of domains. See @sec-crs-svg for details.
+[Alternatively, we could also test for spatially variable genes (SVGs) within domains to identify genes with spatial expression patterns that vary independently of the spatial arrangement of domains; see @sec-crs-svg for details.]{.aside}
 
 ```{r mgs}
 # using scran package
@@ -221,37 +193,38 @@ top <- lapply(mgs, \(df) rownames(df)[df$Top <= 2])
 length(top <- unique(unlist(top)))
 ```
 
-We can visualize selected marker genes as a heatmap where bins represent the average expression (here, log-transformed library size-normalized counts) of a given gene (= columns) in a given cluster (= rows).
-[To visually amplify differences, we use `scale = "column"`. This will, for every gene, subtract the mean and divide by the standard deviation across per-cluster means, bringing genes of potentially very different expression levels to a comparable scale.]{.aside}
+We can visualize selected markers as a heatmap (of cluster-wise expression means):
 
-```{r plt-mgs-hm, fig.width=9, fig.height=3}
+```{r plt-mgs-hm, fig.width=8, fig.height=3}
 #| code-fold: true
+# compute cluster-wise averages
 pbs <- aggregateAcrossCells(spe, 
     ids = spe$BayesSpace, subset.row = top, 
     use.assay.type = "logcounts", statistics = "mean")
-
 # use gene symbols as feature names
 mtx <- t(assay(pbs))
 colnames(mtx) <- rowData(pbs)$gene_name
-
 # using pheatmap package
 pheatmap(mat = mtx, scale = "column")
 ```
 
-In addition, we can plot in x-y space, i.e. coloring spots by their expression of a given marker gene.
+Or spatial plots (of spot-level expression values):
 
-```{r plt-mgs-xy, fig.width=8, fig.height=5.5, message=FALSE}
-ps <- lapply(
-    c("MBP", "PLP1", "NRGN", "SNAP25", "NEFL", "HPCAL1"), \(.) 
-    plotCoords(spe, annotate = ., feature_names = "gene_name", 
-               assay_name = "logcounts"))
-
+```{r plt-mgs-xy, fig.width=6, fig.height=4, message=FALSE}
+#| code-fold: true
+# gene-wise spatial plots
+gs <- c("MBP", "PLP1", "NRGN", "SNAP25", "NEFL", "HPCAL1")
+ps <- lapply(gs, \(.) {
+    plotCoords(spe, 
+        annotate = ., 
+        feature_names = "gene_name", 
+        assay_name = "logcounts") })
+# figure arrangement
 wrap_plots(ps, nrow = 2) & 
   theme(legend.key.width = unit(0.4, "lines"), 
         legend.key.height = unit(0.8, "lines")) & 
   scale_color_gradientn(colors = rev(hcl.colors(9, "Rocket")))
 ```
-
 
 ## Appendix
 

--- a/inst/pages/seq-processing.qmd
+++ b/inst/pages/seq-processing.qmd
@@ -31,7 +31,7 @@ set.seed(123)
 
 ### Load data
 
-Here, we load 10x Genomics Visium data on a postmortem human brain tissue section from the dorsolateral prefrontal cortex (DLPFC) brain region, which has undergone quality control and filtering in the preceeding @sec-seq-quality-control.
+Here, we load 10x Genomics Visium data from one postmortem human brain tissue section from the dorsolateral prefrontal cortex (DLPFC) brain region [@Maynard2021], which has undergone quality control and filtering in the preceeding @sec-seq-quality-control.
 
 <!--
 Here, we load a 10x Genomics Visium dataset that will also be used in several of the following chapters. This dataset has previously been preprocessed using tools outside R and saved in `SpatialExperiment` format, and is available for download from the `r BiocStyle::Biocpkg("STexampleData")` package.
@@ -40,7 +40,7 @@ This dataset consists of one sample (Visium capture area) of postmortem human br
 -->
 
 ```{r load-data, message=FALSE}
-# load data from STexampleData package
+# load data saved in previous chapter
 (spe <- readRDS("seq-spe_qc.rds"))
 ```
 
@@ -78,7 +78,7 @@ assayNames(spe)
 
 ### Highly variable genes (HVGs)
 
-Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based data. This makes the simplified assumption that spots can be treated as equivalent to cells.
+Identifying a set of top "highly variable genes" (HVGs) is a standard step for feature selection in many scRNA-seq workflows, which can also be used as a simple and fast baseline approach in spot-based ST data. This makes the simplified assumption that spots can be treated as equivalent to cells.
 
 Here, we take a standard approach for selecting HVGs; see @sec-crs-hvg for more details. We first remove mitochondrial genes, since these tend to be very highly expressed and are not of main biological interest.
 

--- a/inst/pages/seq-processing.qmd
+++ b/inst/pages/seq-processing.qmd
@@ -14,14 +14,13 @@ Following the processing steps, this chapter also includes short demonstrations 
 ### Dependencies
 
 ```{r load-libs, message=FALSE, warning=FALSE}
-library(SpatialExperiment)
-library(STexampleData)
-library(scater)
 library(scran)
-library(BayesSpace)
+library(scater)
 library(ggspavis)
-library(patchwork)
 library(pheatmap)
+library(patchwork)
+library(BayesSpace)
+library(SpatialExperiment)
 ```
 
 ```{r}


### PR DESCRIPTION
- make `seq-preprocessing` load QCed data from preceding chapter
- in `seq-preprocessing`, prettified xy-plots of marker genes (fewer genes but bigger)
- move contents from `seq-preprocessing` to corresponding `crs-` chapters; specifically
  - HVGs and DEGs to `crs-features`
  - UMAP to `crs-dimension-reduction`
  - update cross-sections references accordingly