### PR TITLE
fixed refs; hide ecosystems printing

### DIFF
--- a/inst/assets/bibliography.bib
+++ b/inst/assets/bibliography.bib
@@ -48,7 +48,6 @@
 % bkg-spatial-omics ============================================================
 
 @article{MethodOfYear2020, 
-    author = {{Nature Methods}}, 
     title = {Method of the Year 2020: spatially resolved transcriptomics}, 
     journal = {Nature Methods}, 
     year = {2021}, 
@@ -59,7 +58,6 @@
 }
 
 @article{MethodOfYear2024, 
-    author = {{Nature Methods}}, 
     title = {Method of the Year 2024: spatial proteomics}, 
     journal = {Nature Methods}, 
     year = {2024}, 

--- a/inst/pages/bkg-ecosystem.qmd
+++ b/inst/pages/bkg-ecosystem.qmd
@@ -72,7 +72,7 @@ available through Bioconductor; some packages might have been deprecated
 at one point or another.
 :::
 
-```{r echo=FALSE, message=FALSE, fig.width=5, fig.height=4}
+```{r echo=FALSE, message=FALSE, results="hide"}
 # dependencies
 library(dplyr)
 library(ggplot2)
@@ -96,6 +96,11 @@ gg <- lapply(ids, \(id) {
     # get cumulative number of packages available each month
     ys |> group_by(date) |> count()
 }) |> bind_rows(.id="biocViews")
+# NOTE: 'getYearsInBioc()' function 
+# will be added in the next release
+```
+
+```{r echo=FALSE, message=FALSE, fig.width=5, fig.height=4}
 ggplot(gg, aes(date, n, col=biocViews)) + 
     geom_line(linewidth=0.8) +
     geom_smooth(data=filter(gg, n >= 5), 
@@ -106,8 +111,6 @@ ggplot(gg, aes(date, n, col=biocViews)) +
         aspect.ratio=1, 
         panel.grid.minor=element_blank(),
         axis.text.x=element_text(angle=45, hjust=1))
-# NOTE: 'getYearsInBioc()' function 
-# will be added in the next release
 ```
 
 To get an idea of the project's "growth" in this space, we can regress the 

--- a/inst/pages/bkg-ecosystem.qmd
+++ b/inst/pages/bkg-ecosystem.qmd
@@ -72,7 +72,8 @@ available through Bioconductor; some packages might have been deprecated
 at one point or another.
 :::
 
-```{r echo=FALSE, message=FALSE, results="hide"}
+```{r message=FALSE, results="hide"}
+#| code-fold: true
 # dependencies
 library(dplyr)
 library(ggplot2)
@@ -100,7 +101,8 @@ gg <- lapply(ids, \(id) {
 # will be added in the next release
 ```
 
-```{r echo=FALSE, message=FALSE, fig.width=5, fig.height=4}
+```{r message=FALSE, fig.width=5, fig.height=4}
+#| code-fold: true
 ggplot(gg, aes(date, n, col=biocViews)) + 
     geom_line(linewidth=0.8) +
     geom_smooth(data=filter(gg, n >= 5), 


### PR DESCRIPTION
- Method of the year references weren't showing correctly (dashes instead of author field). Per Nature Methods website, Method of the year pieces do not have an author field, so removing them should be fine and fixes the rendering.
- "bkd-ecosystems" is printing lots of unwanted stuff (not seeing this when rendering locally, likely due to something being cashed internally); see [here](https://lmweber.org/OSTA/pages/bkg-ecosystem.html#number-of-packages); this should be hidden now.

Current:
<img width="293" height="124" alt="image" src="https://github.com/user-attachments/assets/51921cc1-8164-452d-a64e-98b24205e805" />
Now:
<img width="354" height="135" alt="image" src="https://github.com/user-attachments/assets/f5e874bc-7010-463f-b7f0-9520aedad1ca" />
