### PR TITLE
+`SpaceTrooper` in "img-quality-control"

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -80,6 +80,7 @@ Imports:
     SFEData,
     SingleR,
     sosta,
+    SpaceTrooper,
     spacexr,
     SpatialExperiment,
     SpatialExperimentIO,

--- a/inst/pages/img-quality-control.qmd
+++ b/inst/pages/img-quality-control.qmd
@@ -1,348 +1,638 @@
 # Quality control {#sec-img-quality-control}
 
+```{r include=FALSE}
+knitr::opts_chunk$set(cache=TRUE)
+```
+
 ## Preamble
 
 ### Introduction
 
-The analyses demonstrated here will use a 313-plex Xenium data (10x Genomics) of a human breast cancer biopsy section [@Janesick2023-high-res] and a 1k-plex CosMx data (NanoString) of human non-small cell lung cancer (NSCLC).
+The analyses demonstrated here will use 313-plex Xenium data (10x Genomics) 
+of a human breast cancer biopsy section [@Janesick2023-high-res], and
+1k-plex CosMx data (Bruker) of a mouse brain section.
+These datasets can be accessed through Bioconductor's `ExperimentHub` packages:
+`r BiocStyle::Biocpkg("STexampleData")` and `r BiocStyle::Biocpkg("OSTA.data")`.
 
-In the first section, we demonstrate QC procedures applied to the Xenium dataset, and save the post-QC dataset for use in later chapters. In the second section, we demonstrate additional CosMx-specific QC procedures on the CosMx dataset.
+::: {.aside}
+The CosMx dataset includes additional information, such as fluorescent stains, 
+cell boundaries, field of view placement, etc. that allow us to demonstrate 
+more intricate quality control metrics using the `SpaceTroper` package.
+:::
 
-These datasets can be accessed through the `r BiocStyle::Biocpkg("STexampleData")` package as part of Bioconductor's `ExperimentHub`.
-
+Throughout this chapter, we will switch between Xenium (`xen`) and CosMx (`cos`)
+datasets in order to showcase quality control (QC) metrics that are standard for 
+scRNA-seq data, or specific to different types of imaging-based ST data. Lastly,
+we will save the post-QC Xenium dataset for use in later chapters.
 
 ### Dependencies
 
 ```{r deps, message=FALSE, warning=FALSE}
+library(arrow)
 library(dplyr)
 library(tidyr)
 library(scater)
 library(ggplot2)
+library(ggspavis)
 library(patchwork)
+library(OSTA.data)
+library(SpaceTrooper)
 library(STexampleData)
 library(SpatialExperiment)
+library(SpatialExperimentIO)
 ```
 
+## Importing data
 
-### Load Xenium dataset
+`r BiocStyle::Biocpkg("SpatialExperimentIO")` provides functions to import 
+CosMx (Bruker), Xenium (10x Genomics), and MERSCOPE (Vizgen) datasets into
+`SingleCell/SpatialExperiment` objects, starting from the outputs provided 
+by the three providers. 10x Genomics-specific readers are provided by 
+`r BiocStyle::Biocpkg("TENxIO")`, `r BiocStyle::Biocpkg("VisiumIO")`, and 
+`r BiocStyle::Biocpkg("XeniumIO")`; data from most commercial platforms can 
+also be read using `r BiocStyle::Biocpkg("SpatialFeatureExperiment")` function.
 
-Load the Xenium dataset from the `r BiocStyle::Biocpkg("STexampleData")` package.
+::: {.aside}
+See [@sec-bkg-importing-data] for details on data importing and representation.
+:::
 
-```{r load-data-xenium, message=FALSE, warning=FALSE}
-xen <- Janesick_breastCancer_Xenium_rep1()
+### From Xenium
+
+We load the Xenium dataset from `r BiocStyle::Biocpkg("STexampleData")`:
+
+```{r load-data-xen, message=FALSE, results="hold"}
+(xen <- Janesick_breastCancer_Xenium_rep1())
+# required for visuals
+xen$in_tissue <- TRUE 
+xen$sample_id <- "Xenium"
 ```
 
-Plot the x-y coordinates.
+```{r load-data-xen-hide, message=FALSE, warning=FALSE, echo=FALSE, eval=FALSE}
+# retrieve Xenium dataset from OSF repo
+id <- "Xenium_HumanBreast1_Janesick"
+pa <- OSTA.data_load(id)
+dir.create(td <- tempfile())
+unzip(pa, exdir=td)
+xen <- readXeniumSXE(td)
 
-```{r plot-xy-xenium, echo=TRUE, out.width="66%", fig.align="center"}
-par(mar = rep(0, 4))
-plot(spatialCoords(xen), cex = 0.1, pch = 16, asp = 1, 
-     axes = FALSE, xlab = "", ylab = "")
+# add cell boundary polygons
+pol <- metadata(xen)$cell_boundaries
+pol <- readPolygonsXenium(pol, "parquet")
+pol <- pol[match(xen$cell_id, pol$cell_id), ]
+xen$polygons <- pol
+
+# compute cell aspect ratios
+xen$AspectRatio <- apply(pol, 1, \(.) {
+    if (.$is_multi) return(NA)
+    xy <- .$global[[1]]
+    rng <- colRanges(xy)
+    dxy <- rowDiffs(rng)
+    dxy[2]/dxy[1]
+})
+
+# retrieve FOV information
+mol <- metadata(xen)$transcripts
+mol <- read_parquet(mol, as_data_frame=FALSE)
+idx <- pull(mol, "cell_id")
+idx <- match(xen$cell_id, idx)
+fov <- pull(mol[idx, ], "fov")
+
+# add metadata for 'ggspavis' & 'SpaceTrooper'
+xen$in_tissue <- TRUE
+xen$sample_id <- "Xenium"
+metadata(xen)$technology <- "10x_Xenium"
+
+# altExp = negative & blank codes, metadata include
+# transcripts = molecule coordinates (.pq file)
+# cell/nucleus_boundaries = segmentation (.pq files)
+xen
 ```
 
+### From CosMx
 
-### Load CosMx dataset
+To load the CosMx data into a `SpatialExperiment` object, 
+we use `SpatialExperimentIO`'s `readCosmxSXE` function. 
+To not confuse RNA target counts with counts stemming from either negative 
+probes and system controls, the latter are moved into `altExp`s by default.
+We also add additional `colData` and `metadata` slots that are expected by 
+`r BiocStyle::Biocpkg("ggspavis")` (for visualization) and 
+`r BiocStyle::Biocpkg("SpaceTrooper")` (for analysis);
+see comments in the following code chunks.
 
-Load the CosMx dataset from the `r BiocStyle::Biocpkg("STexampleData")` package.
+::: {.aside}
+See @sec-img-introduction for details on the three main types 
+of barcodes: RNA targets, negative probes, and system controls.]
+:::
 
-```{r load-data-cosmx, message=FALSE, warning=FALSE}
-cos <- CosMx_lungCancer()
+```{r load-data-cos, message=FALSE, warning=FALSE}
+# retrieve CosMx dataset from OSF repo
+id <- "CosMx1k_MouseBrain2"
+pa <- OSTA.data_load(id)
+dir.create(td <- tempfile())
+unzip(pa, exdir=td)
+cos <- readCosmxSXE(td)
+
+# add cell boundary polygons
+pol <- metadata(cos)$polygons
+pol <- readPolygonsCosmx(pol, "parquet")
+idx <- sprintf("f%s_c%s", cos$fov, cos$cell_ID)
+cos$polygons <- pol[match(idx, pol$cell_id), ]
+
+# add metadata for 'ggspavis' & 'SpaceTrooper'
+cos$in_tissue <- TRUE
+cos$sample_id <- "CosMx"
+cos$cell_id <- colnames(cos)
+metadata(cos)$technology <- "Nanostring_CosMx"
+metadata(cos)$fov_dim <- c(xdim=4256, ydim=4256)
+
+# altExp = negative probes, metadata include:
+# transcripts = molecule coordinates (.pq file)
+# polygons = segmentation boundaries (.pq file)
+# fov_pos = FOV corner coordinates (data.frame)
+cos
 ```
 
+## Visualization
 
-## QC using Xenium dataset
+Imaging-based ST data relies on imaging a 2D tissue section. Hence, an advantage 
+compared to scRNA-seq is that we can readily visualize a 2D map of the cells and 
+directly plot cell features onto the map.
+The easiest way to visualize the data is by representing the cells as centroids. 
+This is useful to have a global bird's-eye-view of the tissue.
 
-### Exploratory analyses
-
-Calculate QC metrics using `r BiocStyle::Biocpkg("scater")` package.
-
-```{r}
-spe <- xen
+```{r plot-xy, fig.width=10, fig.height=5}
+# spatial plots for datasets acquired through
+# Xenium & CosMx (points = cell centroids)
+plotCoords(xen, point_size=0) + ggtitle("Xenium") +
+plotCoords(cos, point_size=0) + ggtitle("CosMx") 
 ```
 
-```{r calc-qc}
-spe <- addPerCellQCMetrics(spe, use.altexps = TRUE)
-df <- data.frame(colData(spe), spatialCoords(spe))
+## General QC metrics
+
+Similarly to scRNA-seq, quality control (QC) is an important step to remove 
+low-quality cells and highlights specific biases in the data at the sample, 
+field of view (FOV), or slide area level. Unlike scRNA-seq and sequencing-based 
+ST, however, most imaging-based ST platforms do not measure the transcriptome, 
+nor an "unbiased" sample of it, but rely on the design of gene panels. 
+
+Depending on the platform and the application, such gene panels 
+may be pan-tissue or targeting specific tissues or cell types. 
+Moreover, they vary from a few hundreds (e.g., 313 in the first Xenium panel) 
+to several thousands (e.g., the 5k Xenium panel or the 6k and 18k CosMx panels). 
+Hence, unlike in sequencing-based platforms, we may not have enough
+ribosomal or mitochondrial transcripts to use for computing QC metrics. 
+However, imaging-based platforms provide a set of negative probes 
+that can be used to check for aspecific RNA captures.
+
+Finally, imaging-based platforms include, in addition to transcripts data, 
+morphology information (such as area and eccentricity of segmented cells) 
+and information from antibody stains (such as those targeting cell nuclei 
+or surface; see above).
+
+### scRNA-seq
+
+We start out by computing QC metrics that are standard for scRNA-seq data,
+using the `r BiocStyle::Biocpkg("scuttle")` package. Here, `use.altexps=TRUE`
+allows quantification across alternative features, such as negative probes, 
+in addition to RNA targets, which are contain in the primary object's `assay`.
+[See also @sec-seq-quality-control.]{.aside}
+
+```{r scuttle-qc}
+# compute standard scRNA-seq QC metrics for the Xenium dataset (e.g.,
+# total counts & unique features, for RNA targets & negative probes)
+xen <- addPerCellQCMetrics(xen, use.altexps=TRUE)
 ```
 
-Imaging-based ST data relies on imaging a 2D tissue section. Cells thus represent a slice through a 3D system, and we expect a tight relationship between a cell's counts and area.
+### IF staining
 
-When we inspect total counts and cell areas as separate (univariate) distributions, both appear to follow approximate log-normal distributions.
+CosMx outputs, for instance, typically include the min/max/mean intensities 
+of a set of immunofluorescence (IF) markers for, e.g., nuclei and cell surface 
+(used for segmentation), as well as additional markers (experiment-dependent).
+Here, we show the distribution of mean IF intensities across the CosMx sample.
+[Values are arcsinh-transformed with a cofactor of 10 for visual purposes]{.aside}
 
-```{r plot-qc-1d, fig.width=6, fig.height=2, warning=FALSE}
+```{r plot-cos-xy-dapi, message=FALSE, fig.width=12, fig.height=4}
 #| code-fold: true
-fd <- pivot_longer(df, c("cell_area", "total_counts"))
-mu <- summarise_at(group_by(fd, name), "value", median)
-
-ggplot(fd, aes(value)) + facet_grid(~ name) + 
-  geom_histogram(bins = 50, linewidth = 0.1, fill = "gray") + 
-  geom_vline(data = mu, aes(xintercept = value), col = "blue") + 
-  geom_text(
-    hjust = -0.1, size = 3, col = "blue", 
-    data = mu, aes(value, 0, label=round(value))) + 
-  scale_x_continuous(NULL, trans = "log10") + ylab("# cells") + 
-  theme_minimal() + 
-  theme(panel.grid.minor = element_blank())
+flu <- grepv("^Mean", names(colData(cos)))
+lapply(flu, \(.) {
+    cos[[.]] <- asinh(cos[[.]]/10)
+    plotCoords(cos, annotate=., point_size=0)
+}) |>
+    wrap_plots(nrow=1) &
+    theme(
+        legend.position="bottom", 
+        legend.key.height=unit(0.4, "lines")) &
+    scale_color_gradientn(colors=pals::jet())
 ```
 
-Similarly, we can visualize the distribution of these metrics in the tissue by plotting cell centroids colored by total counts and cell area, respectively.
+### Morphology
 
-```{r plot-qc-xy, fig.width=9, fig.height=3}
+`SpaceTrooper`'s `spatialPerCellQC` function can be used to compute a set of 
+metrics that are particular to imaging-based ST data; examples listed below.
+In addition, the function incorporates an internal call to `perCellQCMetrics`
+from the `r BiocStyle::Biocpkg("scuttle")` package, to compute some standard 
+scRNA-seq QC metrics on an `altExp`; here, we specify using negatives probes.
+
+- `Area_um`: area in microns
+- `CountArea`: count density = number of transcripts per area
+- `log2AspectRatio`: log2 of the aspect ratio (x-/y-axis) of each cell
+- `ctrl_total_ratio`: proportion of negative probe counts over total counts
+
+::: {.aside}
+Note that metrics also include each cell's distance from horizontal/vertical
+and nearest FOV borders: `dist_border_x/y` and `dist_border`, respectively;
+we will get back to this in @sec-img-quality-control-cos.
+:::
+
+```{r SpaceTrooper-qc, message=FALSE, echo=2:4}
+old <- names(colData(cos))
+# compute 'SpaceTrooper' QC metrics
+cos <- spatialPerCellQC(cos, use_altexps="NegPrb")
+# the following cell metadata are newly available:
+setdiff(names(colData(cos)), old)
+```
+
+### Counts per area
+
+Imaging-based ST data relies on imaging a 2D tissue section. Cells thus represent 
+a slice through a 3D system, and we expect a tight relationship between a cell's 
+counts and its area. When we inspect total counts and cell areas as separate 
+(univariate) distributions, both appear approximately log-normal distributed.
+
+::: {.aside}
+Note that there are many more counts for the CosMx data, mostly because
+there are `r nrow(cos)` features but only `r nrow(xen)` for Xenium.
+:::
+
+```{r plot-qc-1d, fig.width=10, fig.height=3, warning=FALSE}
 #| code-fold: true
-fd <- df |>
-  pivot_longer(c(cell_area, total_counts)) |> 
-  arrange(desc(value)) |> 
-  # crop low / high values for clearer visualization
-  mutate(value = case_when(value < 10 ~ 10, value > 1e3 ~ 1e3, TRUE ~ value))
-
-ggplot(fd, aes(x_centroid, y_centroid, col = value)) + 
-  geom_point(shape = 19, stroke = 0, size = 0.2) + 
-  facet_grid(~ name) + 
-  scale_color_gradientn(
-    colors = hcl.colors(9, "Roma"), 
-    limits = c(10, 1e3), trans = "log10") + 
-  coord_equal() + 
-  theme_void()
+.p <- \(df, xs) {
+    fd <- pivot_longer(df, all_of(xs))
+    mu <- summarise_at(group_by(fd, name), "value", median)
+    ggplot(fd, aes(value)) + facet_grid(~ name) + 
+        geom_histogram(bins=50, linewidth=0.1, fill="gray") + 
+        geom_vline(data=mu, aes(xintercept=value), col="blue") + 
+        geom_text(
+            hjust=-0.1, size=3, col="blue", 
+            data=mu, aes(value, 0, label=round(value))) + 
+        scale_x_continuous(NULL, trans="log10") + ylab("# cells") + 
+        theme_minimal() + theme(panel.grid.minor=element_blank())
+}
+df_cos <- data.frame(colData(cos), spatialCoords(cos))
+df_xen <- data.frame(colData(xen), spatialCoords(xen))
+p2 <- .p(df_cos, c("Area_um", "total"))
+p1 <- .p(df_xen, c("cell_area", "total_counts"))
+p1 + ggtitle("CosMx") | p2 + ggtitle("Xenium")
 ```
 
-In a bivariate setting, however, we observe a bimodal distribution with subsets of cells having more or less than 1 count per $\mu m^2$ (diagonal line).
+Similarly, we can visualize the distribution of these metrics in the tissue 
+by plotting cell centroids colored by total counts and cell area, respectively.
 
-```{r plot-qc-2d-one, fig.width=3, fig.height=3, warning=FALSE}
+```{r plot-qc-xy, message=FALSE, fig.width=12, fig.height=4}
 #| code-fold: true
-df <- data.frame(colData(spe), spatialCoords(spe))
-
-ggplot(df, aes(cell_area, total_counts)) + 
-  geom_point(shape = 16, size = 0.1, alpha = 0.1) + 
-  geom_abline(intercept = 0, slope = 1, col = "blue") + 
-  scale_x_continuous(trans = "log10") + 
-  scale_y_continuous(trans = "log10") + 
-  geom_density2d() +
-  theme_minimal() + 
-  theme(aspect.ratio = 1, 
-        panel.grid.minor = element_blank())
+lapply(c("cell_area", "total_counts"), \(.) {
+    # crop very low/high values for clearer visualization
+    val <- xen[[.]]
+    qs <- quantile(val, c(0.01, 0.99))
+    val <- ifelse(val < qs[1], qs[1], ifelse(val > qs[2], qs[2], val))
+    xen[[.]] <- val
+    plotCoords(xen, annotate=., point_size=0) +
+        theme(legend.key.width=unit(0.5, "lines")) +
+        scale_color_gradientn(colors=unname(pals::jet()), trans="log10")
+}) |> wrap_plots(nrow=1)
 ```
 
-In some cases, a peculiar count-area distribution might be indicative of segmentation problems. When groups of cells are merged together, for example, we might observe fewer counts than expected for a given area (when they are far apart, i.e., empty space is being segmented).
+In a bivariate setting, we observe a positive relationship between counts and area (as expected). 
+However, this dependency is not always linear and may exhibit a bimodal distribution.
 
-Considering the spatial organization of cells falling above / below 1 count per $\mu m^2$ here, it is reasonable to assume that they represent distinct transcriptional states (not technical artefacts).
-
-```{r plot-qc-2d-two, fig.width=4, fig.height=3}
+```{r plot-qc-2d-one, message=FALSE, warning=FALSE, fig.width=6, fig.height=3}
 #| code-fold: true
-hl <- df$total_counts / df$cell_area > 1
-df$hl <- c("gray", "blue")[hl + 1]
-
-ggplot(df, aes(x_centroid, y_centroid, col = hl)) + 
-  geom_point(shape = 19, stroke = 0, size = 0.2, show.legend = FALSE) + 
-  scale_color_identity() + 
-  coord_equal(expand=FALSE) + 
-  theme_void()
+.p <- \(df, x, y) {
+    ggplot(df, aes(.data[[x]], .data[[y]])) + 
+        geom_point(shape=16, size=0, alpha=0.1) + 
+        geom_smooth(method="lm", col="blue") +
+        scale_x_log10() + scale_y_log10() +
+        theme_minimal() + theme(
+            aspect.ratio=1, 
+            panel.grid.minor=element_blank())
+}
+.p(df_cos, "Area_um", "total") + ggtitle("CosMx") +
+.p(df_xen, "cell_area", "total_counts") + ggtitle("Xenium")
 ```
 
+In some cases, a peculiar count-area distribution might be indicative of 
+segmentation problems. Undersegmentation (i.e., when groups of cells are 
+merged together) we might observe fewer counts than expected for a given 
+area (e.g., when they are far apart and empty space is being segmented).
+[An useful metric to explore this issue is the `log2CountArea`, 
+which estimates the transcript density for each cell.]{.aside}
 
-### Filtering
+## CosMx-specific QC {#sec-img-quality-control-cos}
 
-For this demo, we will employ rather stringent filtering criteria to:
+### Fields of view (FOVs)
+
+Imaging-based ST data from CosMx are acquired through iterative imaging 
+of predefined rectangular regions, so-called fields of view (FOV).
+
+Unlike Xenium and MERSCOPE, standard CosMx pipelines do not stitch FOVs, but 
+rather treat each FOV independently. The `colData` of the `SpatialExperiment` 
+object resulting from a CosMx data import will include the FOV of each cell, 
+but it is sometimes tricky to understand (or remember) the relative position 
+of each FOV within the slide. 
+
+`SpaceTrooper`'s `plotZoomFovsMap` function provides an easy way to map FOVs 
+within the slide, allowing to zoom in on a subset of FOVs, while visualizing 
+the global structure of the tissue.
+
+```{r plot-cos-fov, warning=FALSE, fig.width=10, fig.height=5}
+plotZoomFovsMap(cos, 
+    mapPointCol="green",
+    colourBy="Mean.DAPI",
+    fovs=c(98:100, 113:115, 122:124))
+```
+
+Assuming FOV placement aims to capture biologically interesting regions -- 
+regions of interest (ROIs) -- we would expect every FOV to capture a decent 
+number of cells. Issues in image registration or IF staining, however, may 
+affect spot calling and cell segmentation, and can yield FOVs with virtually 
+no cells. We thus advice inspecting the number of cells across FOVs:
+
+```{r cos-plot-ns, fig.height=2, out.width="100%"}
+#| code-fold: true
+ns <- as.data.frame(
+    table(fov=cos$fov), 
+    responseName="n_cells")
+ggplot(ns, aes(fov, n_cells)) + 
+    scale_x_discrete(breaks=c(1, seq(5, max(cos$fov), 5))) +
+    scale_y_continuous(limits=c(0, 1e3), n.breaks=4) +
+    labs(x="field of view (FOV)", y="# cells") +
+    geom_col(fill="blue", alpha=2/3) +
+    coord_cartesian(expand=FALSE) +
+    theme_bw()
+```
+
+It is generally also worth checking that basic QC metrics do not vary across FOVs.
+Of course, such effects will also be driven by differences in subpopulation composition across FOVs.
+However, gross differences in detection efficacy, IF staining, spot calling, segmentation, etc. often still manifest in FOV-level shifts in IF stains and/or RNA target, negative probe, system control counts.
+A simple spot-check is the following type of visualization, but more thorough investigation is advisable 'in the wild', especially so in challenging types of tissue:
+
+```{r cos-plot-qc, warning=FALSE, fig.width=12, fig.height=5}
+#| code-fold: true
+df <- data.frame(colData(cos))
+ys <- c("detected", "total", "Area_um", "log2CountArea")
+ys <- c(grepv("Mean", names(df)), ys)
+fd <- pivot_longer(df, ys) |>
+    mutate(value=case_when(
+        grepl("Mean", name) ~ asinh(value),
+        grepl("total", name) ~ log10(value),
+        grepl("^Area", name) ~ log10(value),
+        TRUE ~ value), fov=factor(fov))
+ggplot(fd, aes(fov, value, fill=fov)) + 
+    facet_wrap(~name, nrow=3, scales="free_y") +
+    geom_boxplot(linewidth=0.2, outlier.size=0.2) +
+    scale_x_discrete(breaks=c(1, seq(10, max(cos$fov), 10))) +
+    theme_minimal() + theme(legend.position="none") +
+    labs(x="field of view (FOV)", y=NULL)
+```
+
+In our example, DAPI stains, RNA target counts (`total`), and the number of
+uniquely detected RNA targets (`detected`) are fairly constant across FOVs; 
+systematic differences seem to reflect morphological differences across FOVs.
+Taken together, we cannot deem any FOVs as being obviously problematic here.
+
+### Border effects
+
+Particularly in CosMx, lack of FOV stitching during cell segmentation can result 
+in fractured and possibly duplicated cells. To investigate potential artefacts 
+related to this, we can use the distance to FOV borders calculated previously.
+
+We can *roughly* estimate cell radii as $A=\pi r^2$ $\leftrightarrow r=\sqrt{A/\pi}$, 
+and use this as a threshold on FOV border distances; i.e., we flag a cell when 
+its centroid is closer to any border than the radius of an average circular cell.
+
+```{r cos-est-rad}
+(r <- sqrt(mean(cos$Area)/pi))
+```
+
+Now, let us visualize total RNA counts against distance to FOV borders, 
+setting the above estimate for radius `r` as a threshold on the latter; 
+we also include rolling means to better highlight global trends:
+
+```{r cos-plot-ds, message=FALSE, warning=FALSE, fig.width=9, fig.height=4}
+#| code-fold: true
+df <- data.frame(colData(cos))
+.p <- \(df, x, y) {
+    ggplot(df, aes(.data[[x]], .data[[y]])) +
+        geom_point(color="grey", size=0) +
+        geom_smooth() + theme_minimal() +
+        geom_vline(xintercept=r, col="red") +
+        geom_vline(xintercept=50, linetype=2)
+}
+p1 <- .p(df, "dist_border", "total") + xlim(0, 500) + ylim(0, 2000)
+p2 <- .p(df, "dist_border", "Area_um") + xlim(0, 500) + ylim(0, 200)
+p3 <- .p(df, "dist_border_x", "log2AspectRatio") + xlim(0, 500)
+p4 <- .p(df, "dist_border_y", "log2AspectRatio") + xlim(0, 500)
+(p1 + p2) / (p3 + p4) 
+```
+
+As expected, we observe a decline in counts near FOV borders, with about 
+`r round(100*mean(df$dist_border < r), 1)`% of cells falling below $r$ (red line) and 
+`r round(100*mean(df$dist_border < 50), 1)`% of cells falling below 50 pixels (dashed line).
+
+These cells exhibit lower total counts and smaller segmented areas, 
+as well as a distorsion in their aspect ratio (thin cells close to 
+the y border and broad cells close to the x boder).
+
+To mitigate potential artefacts in downstream analyses, we may choose to filter 
+out these cells, or otherwise flag them as potentially problematic events to be 
+kept a cautionary eye on. 
+
+```{r cos-plot-ex, warning=FALSE, fig.width=5, fig.height=5}
+#| code-fold: true
+#| layout-ncol: 2
+# highlight border cells across 
+# the tissue (using cell centroids)
+cos$ex <- df$dist_border < r
+plotCentroids(cos, colourBy="ex", sampleId=NULL) +
+    scale_color_manual(values=c("lavender", "blue")) +
+    guides(col=guide_legend(override.aes=list(size=2))) +
+    theme_void() + theme(legend.key.size=unit(0, "pt")) +
+    scale_y_reverse() # needed to align with 'ggspavis'
+    
+# zoom in on subset of FOVs
+# visualizing cell boundaries
+fs <- c(98:100, 113:115, 122:124)
+plotPolygons(
+    cos[, cos$fov %in% fs], 
+    colourBy="ex", sampleId=NULL,
+    borderCol="black", palette=c("lavender", "blue")) +
+    theme(legend.position="none") + scale_y_reverse()
+```
+
+## Identifying low-quality cells
+
+We can now use the QC metrics calculated above to flag 
+(and potentially remove) low-quality cells.
+
+### Individual metrics
+
+First, we can consider metrics separately looking for outliers in their distribution.
+Depending on the metric, we are interested in low-end or high-end outliers (or both). 
+For instance, we may want to exclude too small/large cells as potential artifacts.
+
+`r BiocStyle::Biocpkg("SpaceTrooper")` provides a function to compute outliers 
+of the distribution of any QC metric present in the `colData` of the object. 
+We can then visualize the distribution and outlier threshold with a histogram.
+
+::: {.aside}
+Note that thresholds could also be obtained using `scuttle`'s `isOutlier` 
+function on the corresponding metric(s); see @sec-img-quality-control-fil.
+:::
+
+```{r SpaceTrooper-ol-cos, fig.height=2.5, fig.width=10}
+cos <- computeSpatialOutlier(cos, computeBy="total", method="mc")
+cos <- computeSpatialOutlier(cos, computeBy="Area_um", method="mc")
+plotMetricHist(cos, metric="total", useFences="total_outlier_mc") +
+plotMetricHist(cos, metric="Area_um", useFences="Area_um_outlier_mc")
+```
+
+In the CosMx data, we identify `r sum(cos$total_outlier_mc != "NO")` outliers 
+for total counts and `r sum(cos$Area_um_outlier_mc != "NO")` outliers for area.
+
+### Combined score
+
+Finally, we can compute an aggregated quality score, which combines a cell's 
+transcript density, aspect ratio and (for CosMx) distance from FOV borders.
+Here, `computeQScore()` will add a (numeric) `quality_score`, 
+and `computeQScoreFlags` will add a (logical) `low_qscore` slot
+to the input SPE's `colData`; the latter flags low-quality cells.
+
+```{r SpaceTrooper-calc-score, message=FALSE}
+# compute quality scores & flag cell's that
+# fall below specified percentile threshold
+cos <- computeQScore(cos)
+cos <- computeQScoreFlags(cos, 
+    qsThreshold=0.1, 
+    useQSQuantiles=TRUE)
+
+# the following slots have now been 
+# added to the object's cell metadata
+nms <- names(colData(cos))
+sco <- grepv("score$", nms)
+head(colData(cos)[sco])
+```
+
+```{r SpaceTrooper-plot-score, message=FALSE, fig.width=10, fig.height=5}
+#| code-fold: true
+# visualize quality scores & highlight flagged cells
+thm <- list(
+    theme_void(), ggtitle(""), 
+    coord_equal(), scale_y_reverse())
+plotCentroids(cos, colourBy="quality_score") + thm +
+plotCentroids(cos, colourBy="low_qscore") + thm +
+    guides(col=guide_legend(override.aes=list(size=2))) +
+    scale_color_manual(values=c("lavender", "blue")) +
+    theme(legend.key.size=unit(0, "pt")) 
+```
+
+We can see how the quality score flags several cells close to the tissue borders 
+in the CosMx data and cells in the bottom-center damaged area in the Xenium data.
+
+## Filtering {#sec-img-quality-control-fil}
+
+For the Xenium dataset, we will employ rather stringent filtering criteria to:
 
 - exclude cells with too few counts per area (thresholding on MADs)
 - exclude cells with *any* negative probe or system control counts
 
-```{r calc-ol, fig.width=4, fig.height=3}
-nc <- spe$total_counts / spe$cell_area
-ol <- isOutlier(nc, log = TRUE, type = "lower", nmads = 3)
+```{r xen-ol}
+# estimate threshold on counts per area
+# (3 MADs from the median, using log2 scale)
+nc <- xen$total_counts / xen$cell_area
+ol <- isOutlier(nc, log=TRUE, type="lower", nmads=3)
 (th <- attr(ol, "threshold")[1])
-
-par(mar = c(4, 4, 0, 0))
-hist(log(nc), n = 1e3, 
-     main = NULL, ylab = "# cells", 
-     xlab = "log(total_counts / cell_area)")
-abline(v = log(th), col = "blue")
 ```
 
-```{r calc-ex}
+```{r xen-plot-ol, fig.width=4, fig.height=3}
+#| code-fold: true
+# visualize histrogram of counts 
+# per area, including threshold
+par(mar=c(4, 4, 0, 0))
+hist(log(nc), 
+    n=50, col="lavender",
+    main=NULL, ylab="# cells", 
+    xlab="log(total_counts / cell_area)")
+abline(v=log(th), col="blue")
+```
+
+```{r xen-ex}
+# fraction of low-quality Xenium cells
 mean(ex <- ol | 
-       spe$control_probe_counts > 0 | 
-       spe$control_codeword_counts > 0)
+    xen$control_probe_counts > 0 | 
+    xen$control_codeword_counts > 0)
 ```
 
-Before finalizing to exclude any cells, it is recommended to inspect where these fall in the tissue. We would expect low-quality cells to be distributed randomly, and otherwise to accumulate at the tissue borders or in regions were tissue was, for example, smudged, detached, necrotic, etc.
+For the CosMx dataset, we might filter based on `SpaceTrooper`s quality score,
+which would exclude about `r round(100*mean(cos$low_qscore))`\% of cells.
 
-In general, **spatially organized clusters of excluded cells might indicate a bias towards excluding specific types of cells** (e.g. some cells tend to be smaller or might otherwise contain fewer counts due to the panel design).
-
-Whenever possible, we advise readers to cross-check visualizations such as the following with a corresponding H&E stain of the tissue, considering possible experimental faults as well as their prior knowledge on the tissue pathology.
-
-```{r plot-ex, echo=FALSE, out.width="66%", fig.align="center"}
-par(mar = rep(0, 4))
-plot(spatialCoords(spe), col = c("gray", "blue")[ex+1], 
-     cex = 0.1, pch = 16, asp = 1, axes = FALSE, 
-     xlab = "", ylab = "")
+```{r cos-ex}
+# fraction of low-quality CosMx cells
+mean(cos$low_qscore)
 ```
 
+## Conclusion
+
+In a stringent analysis, we may want to remove low-quality cells, but this has 
+to be done with caution: **before excluding any cells, it is recommendable to 
+inspect where these fall in the tissue**. We would expect low-quality cells to 
+be distributed randomly, and otherwise to accumulate at the tissue borders or 
+in regions were tissue was, for example, smudged, detached, necrotic etc.
+
+In general, **spatially organized clusters of excluded cells might indicate a 
+bias towards exclude specific types of cells** (e.g., some immune cells tend to 
+be smaller or might otherwise contain fewer contains due to the panel design).
+Whenever possible, we advice readers to cross-check visualizations like the 
+following with a corresponding H&E stain of the tissue, considering possible 
+experimental faults as well as their prior knowledge on tissue pathology.
+
+```{r plot-ex, echo=FALSE, fig.width=12, fig.height=6}
+# 'ggspavis' complains about duplicated entries
+i <- setdiff(
+    names(cd <- colData(cos)), 
+    spatialCoordsNames(cos))
+colData(cos) <- cd[i] 
+# add for visualization
+xen$ex <- ex; cos$ex <- cos$low_qscore
+plotCoords(xen, annotate="ex") +
+plotCoords(cos, annotate="ex") +
+    plot_layout(guides="collect") &
+    scale_color_manual(values=c("lavender", "blue")) &
+    guides(col=guide_legend(override.aes=list(size=2))) &
+    theme_void() & theme(
+        legend.key.size=unit(0, "pt"),
+        plot.title=element_text(hjust=0.5))
+xen$ex <- cos$ex <- NULL # drop for saving
+```
+
+## Appendix
 
 ### Save data
 
 ```{r save-data}
-saveRDS(spe[, !ex], "img-spe_qc.rds")
+# save filtered Xenium data
+# for consecutive chapters
+saveRDS(xen[, !ex], "img-spe_qc.rds")
 ```
 
+### Resources
 
-## CosMx-specific QC
-
-To not confuse RNA targets with negative probe counts, we will move these from the main data into an `altExp`, and compute basic cell-level QC metrics for both RNA targets and negative probes.
-
-For simplicity, we also relabel spatial coordinates.
-
-```{r}
-spe <- cos
-```
-
-```{r}
-neg <- grep("NegPrb", rownames(spe))
-altExp(spe, "NegPrb") <- spe[neg, ]
-spatialCoordsNames(spe) <- c("x", "y")
-
-# calculate QC metrics
-(spe <- addPerCellQC(spe[-neg, ], use_altexps = TRUE))
-```
-
-
-### FOV effects
-
-Imaging-based ST data from CosMx are acquired through iterative imaging of predefined rectangular regions, so-called fields of view (FOV).
-
-```{r cosmx-plot-xy, fig.width=3, fig.height=2, message=FALSE, warning=FALSE}
-#| code-fold: true
-xy <- spatialCoordsNames(spe)
-df <- data.frame(colData(spe), spatialCoords(spe))
-fd <- df |> 
-  group_by(fov) |> 
-  summarise(across(xy, median))
-
-ggplot(df, aes(x, y, col = factor(fov))) + 
-  geom_point(shape = 16, stroke = 0, size = 0.2) + 
-  geom_text(aes(label = fov), fd, col = "black", size = 2) + 
-  coord_equal(expand = FALSE) + 
-  theme_void() + 
-  theme(legend.position = "none")
-```
-
-Assuming FOV placement was done with the aim of capturing biologically interesting regions of the tissue, we would expect every FOV to capture a reasonable number of cells.
-
-Issues in image registration or IF staining, however, may affect spot calling and cell segmentation, and can yield FOVs with virtually no cells. We thus advise inspecting the number of cells across FOVs.
-
-```{r cosmx-plot-ns, fig.width=4, fig.height=2}
-#| code-fold: true
-ns <- as.data.frame(table(fov = spe$fov), responseName = "n_cells")
-
-ggplot(ns, aes(fov, n_cells)) + 
-  geom_col() + 
-  scale_x_discrete(breaks = c(1, seq(5, max(spe$fov), 5))) + 
-  scale_y_continuous(limits = c(0, 6e3), n.breaks = 4) + 
-  labs(x = "field of view (FOV)", y = "# cells") + 
-  coord_cartesian(expand = FALSE) + 
-  theme_minimal()
-```
-
-It is generally also worth checking that basic QC metrics do not vary across FOVs.
-
-Such effects will also be driven by differences in subpopulation composition across FOVs. However, gross differences in detection efficacy, IF staining, spot calling, segmentation, etc, often still manifest in FOV-level shifts in IF stains and/or RNA target, negative probe, system control counts.
-
-A simple spot-check is the following type of visualization, but more thorough investigation is advisable in a real analysis, especially in challenging types of tissue.
-
-```{r cosmx-plot-qc, warning=FALSE, fig.width=12, fig.height=4}
-#| code-fold: true
-vs <- "Mean|sum|detected|percent"
-vs <- grep(vs, names(df), value = TRUE)
-fd <- pivot_longer(df, vs) |> 
-  mutate(value = case_when(
-    grepl("Mean", name) ~ asinh(value), 
-    grepl("^sum", name) ~ log10(value), 
-    TRUE ~ value))
-
-ggplot(fd, aes(factor(fov), value)) + 
-  facet_wrap(~ name, nrow = 2, scales = "free_y") + 
-  geom_boxplot(linewidth = 0.2, outlier.size = 0.2) + 
-  scale_x_discrete(breaks = c(1, seq(5, max(spe$fov), 5))) + 
-  labs(x = "field of view (FOV)", y = NULL) + 
-  theme_minimal()
-```
-
-In our example, DAPI stains and RNA target counts (`sum`) are fairly constant across FOVs.
-
-FOVs 1-4 have decreased signal for CD3 and CD45, however, this might be related to fewer immune cells being present in these regions rather than technical artefacts.
-
-Taken together, we cannot deem any FOVs as being obviously problematic here.
-
-
-### Border effects
-
-Particularly in CosMx, lack of FOV stitching during cell segmentation can result in fractured and possibly duplicated cells.
-
-To investigate potential artefacts related to this, we can estimate each cell's distance to every FOV border (precise distances would require considering the exact FOV placement coordinates).
-
-```{r cosmx-calc-ds}
-# compute distance to FOV borders
-x <- spe$CenterX_local_px
-y <- spe$CenterY_local_px
-d <- cbind(
-  bottom = y - min(y), top = max(y) - y, 
-  left = x - min(x), right = max(x) - x)
-```
-
-We can *roughly* estimate cell radii as $A=\pi r^2$ $\leftrightarrow r=\sqrt{A/\pi}$, and use this as a threshold on FOV border distances.
-
-In other words, we exclude a cell when its centroid is closer to any FOV border than the radius of an average circular cell.
-
-```{r cosmx-est-r}
-(r <- sqrt(mean(spe$Area)/pi))
-```
-
-Next, let us visualize total RNA counts against distance to FOV borders, setting the above threshold on the latter. We also include rolling means to better highlight global trends.
-
-```{r comsmx-plot-ds, warning=FALSE, fig.width=10, fig.height=3}
-#| code-fold: true
-df <- data.frame(colData(spe), spatialCoords(spe), d)
-fd <- df |> 
-  pivot_longer(colnames(d), values_to = "d")
-mu <- fd |> 
-  group_by(name) |> 
-  arrange(d) |> 
-  mutate(across(c(d, sum), 
-                zoo::rollmean, k = 100, align = "right", fill = NA))
-
-ggplot(fd, aes(d, sum)) + 
-  facet_grid(~ name) + 
-  geom_point(shape = 16, size = 0.4, alpha = 0.2, col = "navy") + 
-  geom_line(data = mu, col = "blue", linewidth = 0.4) + 
-  geom_vline(xintercept = r, col = "gold") + 
-  labs(x = "distance to FOV border (px)", y = "total counts (RNA)") + 
-  scale_y_continuous(limits = c(10, 1e3), trans = "log10") + 
-  coord_cartesian(xlim = c(0, 200)) + 
-  theme_bw() + 
-  theme(aspect.ratio = 1, 
-        legend.position = "none", 
-        panel.grid.minor = element_blank())
-```
-
-As expected, we observe a decline in counts near FOV borders, with about `r round(100*mean(rowAnys(d < r)), 1)`% of cells falling below $r$.
-
-To mitigate potential artefacts in downstream analyses, we may choose to filter out these cells, or otherwise flag them as potentially problematic events to be kept a cautionary eye on.
-
-```{r cosmx-calc-ex}
-# drop cells too close to FOV borders
-mean(ex <- rowAnys(d < r))
-```
-
-```{r cosmx-plot-ex, fig.width=3, fig.height=2, fig.cap="Tissue plot with cells that lie too close to FOV borders highlighted in color."}
-#| code-fold: true
-ggplot(df, aes(x, y, col = ex)) + 
-  geom_point(shape = 16, stroke = 0, size = 0.2) + 
-  scale_color_manual(values = c("gray", "blue")) + 
-  coord_equal(expand=FALSE) + 
-  theme_void() + 
-  theme(legend.position = "none")
-```
-
-
-## Appendix
+Bruker's [CosMx Analysis Scratch Space](
+https://nanostring-biostats.github.io/CosMx-Analysis-Scratch-Space/about.html) 
+provides an exploratory (open-source) resource for CosMx data analysis, which
+includes an FOV-level QC approach that relies on comparing proximal 
+FOVs in order to identify outliers in terms of RNA detection
+(see [here](https://nanostring-biostats.github.io/CosMx-Analysis-Scratch-Space/posts/fov-qc));
+and, a theoretical piece on *background* signal -- i.e., non-RNA target binding events
+(see [here](https://nanostring-biostats.github.io/CosMx-Analysis-Scratch-Space/posts/background)).
 
 ### References {.unnumbered}

--- a/inst/pages/img-quality-control.qmd
+++ b/inst/pages/img-quality-control.qmd
@@ -1,9 +1,5 @@
 # Quality control {#sec-img-quality-control}
 
-```{r include=FALSE}
-knitr::opts_chunk$set(cache=TRUE)
-```
-
 ## Preamble
 
 ### Introduction

--- a/inst/pages/img-quality-control.qmd
+++ b/inst/pages/img-quality-control.qmd
@@ -20,10 +20,12 @@ cell boundaries, field of view placement, etc. that allow us to demonstrate
 more intricate quality control metrics using the `SpaceTroper` package.
 :::
 
-Throughout this chapter, we will switch between Xenium (`xen`) and CosMx (`cos`)
-datasets in order to showcase quality control (QC) metrics that are standard for 
-scRNA-seq data, or specific to different types of imaging-based ST data. Lastly,
-we will save the post-QC Xenium dataset for use in later chapters.
+Throughout this chapter, we will switch between both Xenium (`xen` object) 
+and CosMx (`cos` objext) datasets to showcase quality control (QC) metrics 
+that are standard for scRNA-seq data (using `r BiocStyle::Biocpkg("scuttle")`), 
+and ones that are more specific to some imaging-based ST data types (using 
+`r BiocStyle::Biocpkg("SpaceTrooper")`).
+Lastly, we will save the post-QC Xenium dataset for use in later chapters.
 
 ### Dependencies
 
@@ -121,7 +123,7 @@ see comments in the following code chunks.
 
 ::: {.aside}
 See @sec-img-introduction for details on the three main types 
-of barcodes: RNA targets, negative probes, and system controls.]
+of barcodes: RNA targets, negative probes, and system controls.
 :::
 
 ```{r load-data-cos, message=FALSE, warning=FALSE}
@@ -195,7 +197,10 @@ We start out by computing QC metrics that are standard for scRNA-seq data,
 using the `r BiocStyle::Biocpkg("scuttle")` package. Here, `use.altexps=TRUE`
 allows quantification across alternative features, such as negative probes, 
 in addition to RNA targets, which are contain in the primary object's `assay`.
-[See also @sec-seq-quality-control.]{.aside}
+
+::: {.aside}
+See also @sec-seq-quality-control.
+:::
 
 ```{r scuttle-qc}
 # compute standard scRNA-seq QC metrics for the Xenium dataset (e.g.,
@@ -252,7 +257,7 @@ cos <- spatialPerCellQC(cos, use_altexps="NegPrb")
 setdiff(names(colData(cos)), old)
 ```
 
-### Counts per area
+### Counts \& area
 
 Imaging-based ST data relies on imaging a 2D tissue section. Cells thus represent 
 a slice through a 3D system, and we expect a tight relationship between a cell's 
@@ -366,7 +371,7 @@ ggplot(ns, aes(fov, n_cells)) +
     scale_x_discrete(breaks=c(1, seq(5, max(cos$fov), 5))) +
     scale_y_continuous(limits=c(0, 1e3), n.breaks=4) +
     labs(x="field of view (FOV)", y="# cells") +
-    geom_col(fill="blue", alpha=2/3) +
+    geom_col(fill="grey", alpha=2/3) +
     coord_cartesian(expand=FALSE) +
     theme_bw()
 ```
@@ -376,7 +381,7 @@ Of course, such effects will also be driven by differences in subpopulation comp
 However, gross differences in detection efficacy, IF staining, spot calling, segmentation, etc. often still manifest in FOV-level shifts in IF stains and/or RNA target, negative probe, system control counts.
 A simple spot-check is the following type of visualization, but more thorough investigation is advisable 'in the wild', especially so in challenging types of tissue:
 
-```{r cos-plot-qc, warning=FALSE, fig.width=12, fig.height=5}
+```{r cos-plot-qc, warning=FALSE, fig.width=10, fig.height=5}
 #| code-fold: true
 df <- data.frame(colData(cos))
 ys <- c("detected", "total", "Area_um", "log2CountArea")
@@ -595,7 +600,7 @@ Whenever possible, we advice readers to cross-check visualizations like the
 following with a corresponding H&E stain of the tissue, considering possible 
 experimental faults as well as their prior knowledge on tissue pathology.
 
-```{r plot-ex, echo=FALSE, fig.width=12, fig.height=6}
+```{r plot-ex, echo=FALSE, fig.width=11, fig.height=5}
 # 'ggspavis' complains about duplicated entries
 i <- setdiff(
     names(cd <- colData(cos)), 
@@ -603,14 +608,12 @@ i <- setdiff(
 colData(cos) <- cd[i] 
 # add for visualization
 xen$ex <- ex; cos$ex <- cos$low_qscore
-plotCoords(xen, annotate="ex") +
-plotCoords(cos, annotate="ex") +
+plotCoords(xen, annotate="ex", point_size=0) + ggtitle("Xenium") +
+plotCoords(cos, annotate="ex", point_size=0) + ggtitle("CosMx") +
     plot_layout(guides="collect") &
+    theme(legend.key.size=unit(0, "pt")) &
     scale_color_manual(values=c("lavender", "blue")) &
-    guides(col=guide_legend(override.aes=list(size=2))) &
-    theme_void() & theme(
-        legend.key.size=unit(0, "pt"),
-        plot.title=element_text(hjust=0.5))
+    guides(col=guide_legend(override.aes=list(size=2)))
 xen$ex <- cos$ex <- NULL # drop for saving
 ```
 
@@ -619,7 +622,7 @@ xen$ex <- cos$ex <- NULL # drop for saving
 ### Save data
 
 ```{r save-data}
-# save filtered Xenium data
+# save post-QC Xenium data
 # for consecutive chapters
 saveRDS(xen[, !ex], "img-spe_qc.rds")
 ```


### PR DESCRIPTION
PR consolidating "img-quality-control_SpaceTrooper.qmd" into "img-quality-control.qmd", with some simplifications and restructuring. This was originally drafted by D.Risso and D.Righelli during/post the Zurich hackathon top of the year (still kept a backup, for now).
- CosMx QC now includes IF markers, border effects, FOV visualization, polygon plots, etc.
- Xenium data is only QCed using `scuttle`, with the final object (for consecutive chapeters) identical to before
- Still awaiting `SpaceTrooper` updates, e.g., interop with `SpaExpIO`, an equation for the score, preprint reference